### PR TITLE
CDH: large buffer in ImageProcess

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "simulation"]
 	path = simulation
 	url = https://github.com/cmu-argus-2/GNC-Simulation.git
+	branch = FSW-interface

--- a/flight/apps/adcs/acs.py
+++ b/flight/apps/adcs/acs.py
@@ -20,7 +20,6 @@ def spin_stabilizing_controller(omega: np.ndarray, mag_field: np.ndarray) -> np.
         u_dir = np.zeros((3,))
 
     else:
-
         # Compute Angular Momentum error
         error = PhysicalConst.INERTIA_MAJOR_DIR - np.dot(PhysicalConst.INERTIA_MAT, omega) / ControllerConst.MOMENTUM_TARGET
 
@@ -36,7 +35,6 @@ def spin_stabilizing_controller(omega: np.ndarray, mag_field: np.ndarray) -> np.
 
 
 def sun_pointed_controller(sun_vector: np.ndarray, omega: np.ndarray, mag_field: np.ndarray) -> np.ndarray:
-
     if np.linalg.norm(mag_field) == 0 or np.linlag.norm(sun_vector) == 0:  # Stop ACS if either field is invalid
         u_dir = np.zeros((3,))
     else:
@@ -58,7 +56,6 @@ def sun_pointed_controller(sun_vector: np.ndarray, omega: np.ndarray, mag_field:
 
 
 def mcm_coil_allocator(u: np.ndarray) -> np.ndarray:
-
     # Query the available coil statuses
     coil_status = []
     mcm_alloc = np.zeros((6, 3))

--- a/flight/apps/adcs/ad.py
+++ b/flight/apps/adcs/ad.py
@@ -130,21 +130,29 @@ class AttitudeDetermination:
         """
         if DH.data_process_exists("gps") and SATELLITE.GPS_AVAILABLE:
             # Get last GPS update time and position at that time
-            gps_record_time = DH.get_latest_data("gps")[GPS_IDX.TIME_GPS]
-            gps_pos_ecef = 1e-2 * (
-                np.array(DH.get_latest_data("gps")[GPS_IDX.GPS_ECEF_X : GPS_IDX.GPS_ECEF_Z + 1]).reshape((3,))
-            )
-            gps_vel_ecef = 1e-2 * (
-                np.array(DH.get_latest_data("gps")[GPS_IDX.GPS_ECEF_VX : GPS_IDX.GPS_ECEF_VZ + 1]).reshape((3,))
-            )
+            gps_data = DH.get_latest_data("gps")
 
-            # Sensor validity check
-            if gps_pos_ecef is None or gps_vel_ecef is None or len(gps_pos_ecef) != 3 or len(gps_vel_ecef) != 3:
-                return StatusConst.GPS_FAIL, 0, np.zeros((3,)), np.zeros((3,))
-            elif not (6.0e6 <= np.linalg.norm(gps_pos_ecef) <= 7.5e6) or not (3.0e3 <= np.linalg.norm(gps_vel_ecef) <= 1.0e4):
-                return StatusConst.GPS_FAIL, 0, np.zeros((3,)), np.zeros((3,))
+            if gps_data is not None:
+                gps_record_time = [GPS_IDX.TIME_GPS]
+                gps_pos_ecef = 1e-2 * (
+                    np.array(DH.get_latest_data("gps")[GPS_IDX.GPS_ECEF_X : GPS_IDX.GPS_ECEF_Z + 1]).reshape((3,))
+                )
+                gps_vel_ecef = 1e-2 * (
+                    np.array(DH.get_latest_data("gps")[GPS_IDX.GPS_ECEF_VX : GPS_IDX.GPS_ECEF_VZ + 1]).reshape((3,))
+                )
 
-            return StatusConst.OK, gps_record_time, gps_pos_ecef, gps_vel_ecef
+                # Sensor validity check
+                if gps_pos_ecef is None or gps_vel_ecef is None or len(gps_pos_ecef) != 3 or len(gps_vel_ecef) != 3:
+                    return StatusConst.GPS_FAIL, 0, np.zeros((3,)), np.zeros((3,))
+                elif not (6.0e6 <= np.linalg.norm(gps_pos_ecef) <= 7.5e6) or not (
+                    3.0e3 <= np.linalg.norm(gps_vel_ecef) <= 1.0e4
+                ):
+                    return StatusConst.GPS_FAIL, 0, np.zeros((3,)), np.zeros((3,))
+
+                return StatusConst.OK, gps_record_time, gps_pos_ecef, gps_vel_ecef
+
+            else:
+                return StatusConst.GPS_FAIL, 0, np.zeros((3,)), np.zeros((3,))
         else:
             return StatusConst.GPS_FAIL, 0, np.zeros((3,)), np.zeros((3,))
 

--- a/flight/apps/adcs/ad.py
+++ b/flight/apps/adcs/ad.py
@@ -32,7 +32,6 @@ from ulab import numpy as np
 
 
 class AttitudeDetermination:
-
     # Initialized Flag to retry initialization
     initialized = False
 
@@ -71,6 +70,7 @@ class AttitudeDetermination:
 
     # ------------------------------------------------------------------------------------------------------------------------------------
     """ SENSOR READ FUNCTIONS """
+
     # ------------------------------------------------------------------------------------------------------------------------------------
     def read_sun_position(self) -> tuple[int, np.ndarray, np.ndarray]:
         """
@@ -129,7 +129,6 @@ class AttitudeDetermination:
         - NOTE: Since GPS is a task, this function will read values from C&DH
         """
         if DH.data_process_exists("gps") and SATELLITE.GPS_AVAILABLE:
-
             # Get last GPS update time and position at that time
             gps_record_time = DH.get_latest_data("gps")[GPS_IDX.TIME_GPS]
             gps_pos_ecef = 1e-2 * (
@@ -151,6 +150,7 @@ class AttitudeDetermination:
 
     # ------------------------------------------------------------------------------------------------------------------------------------
     """ MEKF INITIALIZATION """
+
     # ------------------------------------------------------------------------------------------------------------------------------------
     def initialize_mekf(self) -> int:
         """
@@ -258,6 +258,7 @@ class AttitudeDetermination:
 
     # ------------------------------------------------------------------------------------------------------------------------------------
     """ MEKF PROPAGATION """
+
     # ------------------------------------------------------------------------------------------------------------------------------------
     def position_update(self, current_time: int) -> None:
         """
@@ -354,7 +355,6 @@ class AttitudeDetermination:
         self.state[self.omega_idx] = omega_body  # save omega to state
 
         if status == StatusConst.OK:
-
             if self.initialized:  # If initialized, also update attitude via propagation
                 bias = self.state[self.bias_idx]
                 dt = current_time - self.last_gyro_update_time
@@ -375,7 +375,6 @@ class AttitudeDetermination:
                 self.last_gyro_update_time = current_time
 
                 if update_covariance:  # if update covariance, update covariance matrices
-
                     F = np.zeros((6, 6))
                     F[0:3, 3:6] = -R_q_next
 
@@ -403,7 +402,6 @@ class AttitudeDetermination:
         status, _, mag_field_body = self.read_magnetometer()
 
         if self.initialized and update_covariance and status == StatusConst.OK:  # Update EKF
-
             true_mag_field_eci = igrf_eci(current_time, self.state[self.position_idx] / 1000)
             true_mag_field_eci_norm = np.linalg.norm(true_mag_field_eci)
             if true_mag_field_eci_norm == 0:

--- a/flight/apps/adcs/orbit_propagation.py
+++ b/flight/apps/adcs/orbit_propagation.py
@@ -9,7 +9,6 @@ from ulab import numpy as np
 
 
 class OrbitPropagator:
-
     # Storage
     last_update_time = 0
     last_updated_state = np.zeros((6,))
@@ -28,7 +27,6 @@ class OrbitPropagator:
 
     @classmethod
     def propagate_orbit(cls, current_time: int, last_gps_time: int = None, last_gps_state: np.ndarray = None):
-
         if last_gps_state is not None:
             cls.last_updated_state = last_gps_state
             cls.last_update_time = last_gps_time

--- a/flight/apps/eps/eps.py
+++ b/flight/apps/eps/eps.py
@@ -20,12 +20,10 @@ def GET_EPS_POWER_FLAG(curr_flag, soc):
     """returns current EPS state based on SOC"""
     flag = EPS_POWER_FLAG.NONE
     if EPS_POWER_FLAG.NONE <= curr_flag <= EPS_POWER_FLAG.EXPERIMENT:
-
         if 0 <= soc <= EPS_SOC_THRESHOLD.LOW_POWER_ENTRY:  # below low power threshold
             flag = EPS_POWER_FLAG.LOW_POWER
 
         elif EPS_SOC_THRESHOLD.LOW_POWER_ENTRY < soc < EPS_SOC_THRESHOLD.LOW_POWER_EXIT:
-
             if curr_flag == EPS_POWER_FLAG.LOW_POWER:
                 flag = EPS_POWER_FLAG.LOW_POWER
             else:
@@ -39,7 +37,6 @@ def GET_EPS_POWER_FLAG(curr_flag, soc):
             flag = EPS_POWER_FLAG.NOMINAL
 
         elif (soc >= EPS_SOC_THRESHOLD.EXPERIMENT_EXIT) and (soc <= EPS_SOC_THRESHOLD.EXPERIMENT_ENTRY):
-
             if curr_flag == EPS_POWER_FLAG.EXPERIMENT:
                 flag = EPS_POWER_FLAG.EXPERIMENT
             else:

--- a/flight/core/data_handler.py
+++ b/flight/core/data_handler.py
@@ -570,8 +570,9 @@ class ImageProcess(DataProcess):
         self.current_path = self.create_new_path()
         self.delete_paths = []  # Paths that are flagged for deletion
         self.excluded_paths = []  # Paths that are currently being transmitted
-        self.circular_buffer_size = 512  # Default size of the circular buffer for the files in the directory
-        self.img_buf = bytearray(self.circular_buffer_size)  # Pre-allocated static buffer for image process
+        self.circular_buffer_size = 20  # Default size of the circular buffer for the files in the directory
+        self.img_buf_size = 512  # Default size of the circular buffer for image data logs
+        self.img_buf = bytearray(self.img_buf_size)  # Pre-allocated static buffer for image process
         self.img_buf_index = 0  # index to track position in buffer
 
         config_file_path = join_path(self.dir_path, _PROCESS_CONFIG_FILENAME)
@@ -615,30 +616,36 @@ class ImageProcess(DataProcess):
             None
         """
 
-        # Check how much space is left in image buffer
-        data_len = len(data)
-        space_remaining = self.circular_buffer_size - self.img_buf_index
+        if not DataHandler.SD_ERROR_FLAG:
+            # Add to image buffer and transmit only when multiples of 512 Bytes have been attained
+            data_len = len(data)
+            data_offset = 0  # Keeps track of processed data
 
-        if data_len >= space_remaining:
-            # Fill the buffer with remaining data
-            self.img_buf[self.img_buf_index :] = data[:space_remaining]
+            while data_offset < data_len:
+                space_remaining = self.img_buf_size - self.img_buf_index
+                chunk_size = min(data_len - data_offset, space_remaining)  # Fill as much as possible
 
-            # Writing to SD card
-            self.resolve_current_file()
-            self.file.write(self.img_buf[: self.circular_buffer_size])  # write 512 bytes to file
-            self.img_buf_index = 0  # reset index for the buffer
-            self.file.flush()
+                # Copy data into buffer
+                self.img_buf[self.img_buf_index : self.img_buf_index + chunk_size] = data[
+                    data_offset : data_offset + chunk_size
+                ]
+                self.img_buf_index += chunk_size
+                data_offset += chunk_size  # Move data offset
 
-            # Store the over flow data for next time buf is full
-            overflow_len = data_len - space_remaining
-            self.img_buf[:overflow_len] = data[space_remaining:]
-            self.img_buf_index = overflow_len  # set the index to the overflow value
+                if self.img_buf_index == self.img_buf_size:
+                    # Buffer is full, write to SD card
+                    self.resolve_current_file()
+                    self.file.write(self.img_buf[: self.img_buf_size])  # Write full 512-byte block
+                    self.file.flush()
+                    self.img_buf_index = 0  # Reset buffer index
+
         else:
-            # Nominal - just adding to the buffer until full
-            self.img_buf[self.img_buf_index : self.img_buf_index + data_len] = data
-            self.img_buf_index += data_len  # increment index for the buffer
+            # Transmit each time without adding to a buf
+            self.resolve_current_file()
+            self.last_data = data
 
-        self.last_data = data
+            self.file.write(data)
+            self.file.flush()
 
     def request_TM_path(self, latest: bool = False) -> Optional[str]:
         """

--- a/flight/hal/argus_v2.py
+++ b/flight/hal/argus_v2.py
@@ -460,7 +460,6 @@ class ArgusV2(CubeSat):
         from hal.drivers.bq25883 import BQ25883
 
         try:
-
             charger = BQ25883(
                 ArgusV2Components.CHARGER_I2C,
                 ArgusV2Components.CHARGER_I2C_ADDRESS,
@@ -566,7 +565,6 @@ class ArgusV2(CubeSat):
         from hal.drivers.sx126x import SX1262
 
         try:
-
             # Enable power to the radio
             radioEn = digitalio.DigitalInOut(ArgusV2Components.RADIO_ENABLE)
             radioEn.direction = digitalio.Direction.OUTPUT
@@ -701,7 +699,6 @@ class ArgusV2(CubeSat):
         from hal.drivers.max17205 import MAX17205
 
         try:
-
             fuel_gauge = MAX17205(
                 ArgusV2Components.FUEL_GAUGE_I2C,
                 ArgusV2Components.FUEL_GAUGE_I2C_ADDRESS,

--- a/flight/tasks/adcs.py
+++ b/flight/tasks/adcs.py
@@ -78,7 +78,6 @@ class Task(TemplateTask):
             pass
 
         else:
-
             if not DH.data_process_exists("adcs"):
                 data_format = "LB" + 6 * "f" + "B" + 3 * "f" + 9 * "H" + 6 * "B" + 4 * "f"
                 DH.register_data_process("adcs", data_format, True, data_limit=100000, write_interval=5)
@@ -90,7 +89,6 @@ class Task(TemplateTask):
             # DETUMBLING
             # ------------------------------------------------------------------------------------------------------------------------------------
             if SM.current_state == STATES.DETUMBLING:
-
                 # Query the Gyro
                 self.AD.gyro_update(self.time, update_covariance=False)
 
@@ -108,7 +106,6 @@ class Task(TemplateTask):
             # LOW POWER
             # ------------------------------------------------------------------------------------------------------------------------------------
             elif SM.current_state == STATES.LOW_POWER:
-
                 # Turn coils off to conserve power
                 zero_all_coils()
 
@@ -155,7 +152,6 @@ class Task(TemplateTask):
             # NOMINAL & EXPERIMENT
             # ------------------------------------------------------------------------------------------------------------------------------------
             else:
-
                 if (
                     SM.current_state == STATES.NOMINAL
                     and not DH.get_latest_data("cdh")[CDH_IDX.DETUMBLING_ERROR_FLAG]
@@ -217,6 +213,7 @@ class Task(TemplateTask):
 
     # ------------------------------------------------------------------------------------------------------------------------------------
     """ Attitude Control Auxiliary Functions """
+
     # ------------------------------------------------------------------------------------------------------------------------------------
     def attitude_control(self):
         """
@@ -225,7 +222,6 @@ class Task(TemplateTask):
 
         # Decide which controller to choose
         if self.MODE in [Modes.TUMBLING, Modes.STABLE]:  # B-cross controller
-
             # Get sensor measurements
             omega_unbiased = self.AD.state[self.AD.omega_idx] - self.AD.state[self.AD.bias_idx]
             mag_field_body = self.AD.state[self.AD.mag_field_idx]
@@ -234,7 +230,6 @@ class Task(TemplateTask):
             self.coil_status = spin_stabilizing_controller(omega_unbiased, mag_field_body)
 
         else:  # Sun-pointed controller
-
             # Get measurements
             sun_pos_body = self.AD.state[self.AD.sun_pos_idx]
             omega_unbiased = self.AD.state[self.AD.omega_idx] - self.AD.state[self.AD.omega_idx]
@@ -245,6 +240,7 @@ class Task(TemplateTask):
 
     # ------------------------------------------------------------------------------------------------------------------------------------
     """ LOGGING """
+
     # ------------------------------------------------------------------------------------------------------------------------------------
     def log(self):
         """
@@ -284,7 +280,6 @@ class Task(TemplateTask):
         DH.log_data("adcs", self.log_data)
 
         if self.execution_counter == 0:
-
             # Empty failure message buffers
             for msg in self.failure_messages:
                 self.log_warning(msg)

--- a/flight/tasks/payload.py
+++ b/flight/tasks/payload.py
@@ -12,11 +12,9 @@ class Task(TemplateTask):
         self.name = "PAYLOAD"
 
     async def main_task(self):
-
         if SM.current_state == STATES.STARTUP:
             pass
         else:
-
             if not DH.data_process_exists("img"):
                 DH.register_image_process()  # WARNING: Image process from DH is different from regular data processes!
 

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -74,12 +74,17 @@ def test_extract_time_from_filename(input_filename, expected_output):
 
 
 @pytest.fixture
-def sd_root(tmpdir):
-    sd_root = tmpdir.mkdir(dh._HOME_PATH)
+def sd_root(tmp_path):
+    """
+    Creates a temporary SD card root directory for testing.
+    Ensures the path exists before tests use it.
+    """
+    sd_root = tmp_path / "sd_root"
+    sd_root.mkdir(parents=True, exist_ok=True)  # Ensure directory exists
     return sd_root
 
 
-def test_image_log(sd_root):
+def test_image_nominal_log(sd_root):
     dh._HOME_PATH = str(sd_root)  # temporary SD card
     DH.register_image_process()
     assert dh._IMG_TAG_NAME in DH.data_process_registry  # ensure that image process was registered
@@ -89,19 +94,55 @@ def test_image_log(sd_root):
     assert img_process.img_buf_index == 100
 
     DH.log_image(bytearray(412))  # Adding remaining 412 bytes
-    assert os.stat(img_process.current_path)[6] == 512  # Ensure block of 512 was written to file
+    assert os.stat(img_process.current_path).st_size == 512  # Ensure block of 512 was written to file
 
     DH.log_image(bytearray(700))  # Testing overflow
     assert img_process.img_buf_index == 188
-    assert os.stat(img_process.current_path)[6] == 1024
+    assert os.stat(img_process.current_path).st_size == 1024
 
     DH.log_image(bytearray(200))  # Testing not writing if not 512 block
     assert img_process.img_buf_index == 388
-    assert os.stat(img_process.current_path)[6] == 1024
+    assert os.stat(img_process.current_path).st_size == 1024
 
     DH.log_image(bytearray(200))  # Testing a second 512 write
     assert img_process.img_buf_index == 76
-    assert os.stat(img_process.current_path)[6] == 1536
+    assert os.stat(img_process.current_path).st_size == 1536
+
+
+def test_image_edge_case_log(sd_root):
+    # Testing Edge cases with image buffer
+    dh._HOME_PATH = str(sd_root)  # temporary SD card
+    DH.register_image_process()
+    assert dh._IMG_TAG_NAME in DH.data_process_registry  # ensure that image process was registered
+    img_process = DH.data_process_registry[dh._IMG_TAG_NAME]
+
+    # Writing exactly 512 bytes at once
+    DH.log_image(bytearray(512))
+    assert os.stat(img_process.current_path).st_size == 512
+    assert img_process.img_buf_index == 0  # Buffer resets after write
+
+    # Writing nothing should not affect buffer
+    DH.log_image(bytearray(0))
+    assert img_process.img_buf_index == 0  # Should still be empty
+    assert os.stat(img_process.current_path).st_size == 512  # No additional writes
+
+    # Overflow handling when adding 1024 bytes
+    DH.log_image(bytearray(1024))
+    assert os.stat(img_process.current_path).st_size == 1536  # Two full writes
+    assert img_process.img_buf_index == 0  # Buffer should be empty after exact writes
+
+    # Writing in small increments without reaching 512
+    DH.log_image(bytearray(100))
+    assert img_process.img_buf_index == 100
+    assert os.stat(img_process.current_path).st_size == 1536  # No new writes
+
+    DH.log_image(bytearray(411))
+    assert img_process.img_buf_index == 511  # Still no write yet
+    assert os.stat(img_process.current_path).st_size == 1536
+
+    DH.log_image(bytearray(1))  # This should push buffer to 512, triggering a write
+    assert img_process.img_buf_index == 0  # Buffer resets
+    assert os.stat(img_process.current_path).st_size == 2048  # New block written
 
 
 if __name__ == "__main__":

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -8,6 +8,8 @@ import flight.core.data_handler as dh
 from flight.core.data_handler import DataProcess as DP
 from flight.core.data_handler import extract_time_from_filename
 
+DH = dh.DataHandler
+
 
 @pytest.mark.parametrize(
     "data_format, expected_size",
@@ -70,13 +72,37 @@ def test_extract_time_from_filename(input_filename, expected_output):
 
 # TODO - mock filesystem
 
-"""@pytest.fixture
+
+@pytest.fixture
 def sd_root(tmpdir):
-    sd_root = tmpdir.mkdir("sd")
+    sd_root = tmpdir.mkdir(dh._HOME_PATH)
     return sd_root
 
-def test_scan_sd_card(sd_root):
-    DH.sd_path = str(sd_root)"""
+
+def test_image_log(sd_root):
+    dh._HOME_PATH = str(sd_root)  # temporary SD card
+    DH.register_image_process()
+    assert dh._IMG_TAG_NAME in DH.data_process_registry  # ensure that image process was registered
+
+    DH.log_image(bytearray(100))  # Adding 100 bytes
+    img_process = DH.data_process_registry[dh._IMG_TAG_NAME]
+    assert img_process.img_buf_index == 100
+
+    DH.log_image(bytearray(412))  # Adding remaining 412 bytes
+    assert os.stat(img_process.current_path)[6] == 512  # Ensure block of 512 was written to file
+
+    DH.log_image(bytearray(700))  # Testing overflow
+    assert img_process.img_buf_index == 188
+    assert os.stat(img_process.current_path)[6] == 1024
+
+    DH.log_image(bytearray(200))  # Testing not writing if not 512 block
+    assert img_process.img_buf_index == 388
+    assert os.stat(img_process.current_path)[6] == 1024
+
+    DH.log_image(bytearray(200))  # Testing a second 512 write
+    assert img_process.img_buf_index == 76
+    assert os.stat(img_process.current_path)[6] == 1536
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Issue: #172

Added a large buffer to the ImageProcess class for the Onboard Data Handler to improve inter-board data rate by writing to the SD card in blocks of 512 bytes instead of every time we receive data. It is a circular buffer that will collect the logs and then when it hits 512 bytes in the buffer it will write to a file. Any remaining data will be added to the buffer after the write and index variable keeps track of the current size.