### PR TITLE
Emulator Fix

### DIFF
--- a/emulator/configuration.py
+++ b/emulator/configuration.py
@@ -3,7 +3,6 @@ import os
 from core import DataHandler as DH
 from hal.cubesat import CubeSat
 from hal.emulator import EmulatedSatellite
-from hal.simulator import Simulator
 
 DH.sd_path = "sd"
 
@@ -13,8 +12,10 @@ EN_MIDDLEWARE = True
 SIMULATION = bool(int(os.getenv("ARGUS_SIMULATION_FLAG", 0)))
 SOCKET_RADIO = False
 
-SimulatedSpacecraft: Simulator = None
+SimulatedSpacecraft = None
 if SIMULATION:
+    from hal.simulator import Simulator
+
     SimulatedSpacecraft = Simulator()
 
 SATELLITE: CubeSat = EmulatedSatellite(debug=DEBUG_MODE, simulator=SimulatedSpacecraft, use_socket=SOCKET_RADIO)

--- a/flight/apps/adcs/ad.py
+++ b/flight/apps/adcs/ad.py
@@ -133,7 +133,7 @@ class AttitudeDetermination:
             gps_data = DH.get_latest_data("gps")
 
             if gps_data is not None:
-                gps_record_time = [GPS_IDX.TIME_GPS]
+                gps_record_time = DH.get_latest_data("gps")[GPS_IDX.TIME_GPS]
                 gps_pos_ecef = 1e-2 * (
                     np.array(DH.get_latest_data("gps")[GPS_IDX.GPS_ECEF_X : GPS_IDX.GPS_ECEF_Z + 1]).reshape((3,))
                 )

--- a/flight/core/states.py
+++ b/flight/core/states.py
@@ -53,7 +53,7 @@ class STATES:
         LOW_POWER: [NOMINAL, LOW_POWER],
     }
 
-    DETUMBLING_TIMEOUT_DURATION = 300  # seconds - TODO: Update with actual value
+    DETUMBLING_TIMEOUT_DURATION = 30  # seconds - TODO: Update with actual value
 
 
 STR_STATES = ["STARTUP", "DETUMBLING", "NOMINAL", "EXPERIMENT", "LOW_POWER"]


### PR DESCRIPTION
Pr addresses the following:
1. Imports the simulation IFF the SIMULATION flag is set. Allows for the emulator to be run without the simulator and on other operating systems
2. Reduces the DETUMBLING timeout to 30s to allow SIL CI to also check execution in the NOMINAL state

Both ```./run.sh emulate``` (without sim installed) and ```./run.sh simulate``` work