### PR TITLE
Forbid cubesat base class instantiation

### DIFF
--- a/flight/apps/adcs/acs.py
+++ b/flight/apps/adcs/acs.py
@@ -35,7 +35,7 @@ def spin_stabilizing_controller(omega: np.ndarray, mag_field: np.ndarray) -> np.
 
 
 def sun_pointed_controller(sun_vector: np.ndarray, omega: np.ndarray, mag_field: np.ndarray) -> np.ndarray:
-    if np.linalg.norm(mag_field) == 0 or np.linlag.norm(sun_vector) == 0:  # Stop ACS if either field is invalid
+    if np.linalg.norm(mag_field) == 0 or np.linalg.norm(sun_vector) == 0:  # Stop ACS if either field is invalid
         u_dir = np.zeros((3,))
     else:
         # Compute Pointing Error

--- a/flight/hal/cubesat.py
+++ b/flight/hal/cubesat.py
@@ -20,6 +20,9 @@ class CubeSat:
         "_time_ref_boot",
     )
 
+    def __new__(cls, *args, **kwargs):
+        raise TypeError(f"{cls.__name__} is a static base class and cannot be instantiated.")
+
     def __init__(self):
         self.__device_list = OrderedDict(
             [


### PR DESCRIPTION
It should never happen in practice but good to make sure explicitly so it caught in CI.