### PR TITLE
Fixes to HAL and TM Packer and CDH

### DIFF
--- a/flight/apps/command/constants.py
+++ b/flight/apps/command/constants.py
@@ -49,3 +49,16 @@ file_tags_str = {
     9: "gps",
     10: "img",
 }
+
+file_ids_str = {
+    "cmd_logs": 1,
+    "watchdog": 2,
+    "eps": 3,
+    "cdh": 4,
+    "comms": 5,
+    "imu": 6,
+    "adcs": 7,
+    "thermal": 8,
+    "gps": 9,
+    "img": 10,
+}

--- a/flight/apps/command/preconditions.py
+++ b/flight/apps/command/preconditions.py
@@ -1,5 +1,3 @@
-import time
-
 from apps.command.constants import file_tags_str
 from core.data_handler import DataHandler
 from core.state_machine import STATES
@@ -23,19 +21,15 @@ def valid_time_format(*args) -> bool:
     """
     time_reference = args[0]
 
-    if time_reference < 3004213696:  # 40 years into the future
+    if not isinstance(time_reference, int):
+        return False
+
+    # Check that the timestamp is above Jan 1st 2020
+    # Check that the timestamp is below Jan 1st 2080
+    if 1577854800 < time_reference < 3471310800:
         return True
-    return False
-
-    # if time_reference is None:
-    #     return False
-
-    # try:
-    #     # Try to convert it to a time struct will verify if it was of proper UNIX format
-    #     time.gmtime(time_reference)
-    #     return True
-    # except (ValueError, TypeError, OverflowError, OSError):
-    #     return False
+    else:
+        return False
 
 
 def file_id_exists(*args) -> bool:

--- a/flight/apps/command/preconditions.py
+++ b/flight/apps/command/preconditions.py
@@ -33,9 +33,9 @@ def valid_time_format(*args) -> bool:
     while in development.
     """
 
-    # Check that the timestamp is above Jan 1st 2020
-    # Check that the timestamp is below Jan 1st 2080
-    if 1577854800 < time_reference < 3471310800:
+    # Check that the timestamp is above Jan 1st 2020 UTC
+    # Check that the timestamp is below Jan 1st 2030 UTC
+    if 1577836800 < time_reference < 1893456000:
         return True
     else:
         return False

--- a/flight/apps/command/preconditions.py
+++ b/flight/apps/command/preconditions.py
@@ -23,15 +23,19 @@ def valid_time_format(*args) -> bool:
     """
     time_reference = args[0]
 
-    if time_reference is None:
-        return False
-
-    try:
-        # Try to convert it to a time struct will verify if it was of proper UNIX format
-        time.gmtime(time_reference)
+    if time_reference < 3004213696:  # 40 years into the future
         return True
-    except (ValueError, TypeError, OverflowError, OSError):
-        return False
+    return False
+
+    # if time_reference is None:
+    #     return False
+
+    # try:
+    #     # Try to convert it to a time struct will verify if it was of proper UNIX format
+    #     time.gmtime(time_reference)
+    #     return True
+    # except (ValueError, TypeError, OverflowError, OSError):
+    #     return False
 
 
 def file_id_exists(*args) -> bool:

--- a/flight/apps/command/preconditions.py
+++ b/flight/apps/command/preconditions.py
@@ -4,6 +4,9 @@ from core.state_machine import STATES
 
 """ Contains functions to check the preconditions of Commands """
 
+_TIME_RANGE_LOW = 1577836800
+_TIME_RANGE_HIGH = 1893456000
+
 
 def valid_state(*args) -> bool:
     """

--- a/flight/apps/command/preconditions.py
+++ b/flight/apps/command/preconditions.py
@@ -38,7 +38,7 @@ def valid_time_format(*args) -> bool:
 
     # Check that the timestamp is above Jan 1st 2020 UTC
     # Check that the timestamp is below Jan 1st 2030 UTC
-    if 1577836800 < time_reference < 1893456000:
+    if _TIME_RANGE_LOW < time_reference < _TIME_RANGE_HIGH:
         return True
     else:
         return False

--- a/flight/apps/command/preconditions.py
+++ b/flight/apps/command/preconditions.py
@@ -24,6 +24,15 @@ def valid_time_format(*args) -> bool:
     if not isinstance(time_reference, int):
         return False
 
+    """
+    Since CPy time.time() starts on Jan 1st 2020,
+    limit the time reference to at least this date.
+
+    Can also update this to be our launch date,
+    although that will lead to issues in testing
+    while in development.
+    """
+
     # Check that the timestamp is above Jan 1st 2020
     # Check that the timestamp is below Jan 1st 2080
     if 1577854800 < time_reference < 3471310800:

--- a/flight/apps/telemetry/packing.py
+++ b/flight/apps/telemetry/packing.py
@@ -39,6 +39,14 @@ from core import DataHandler as DH
 from core import logger
 from micropython import const
 
+# TM frame sizes as defined in message database
+# TODO: TM HAL
+# TODO: TM PAYLOAD
+_TM_NOMINAL_SIZE = const(227)
+_TM_HAL_SIZE = const(46)
+_TM_STORAGE_SIZE = const(74)
+_TM_PAYLOAD_SIZE = const(0)
+
 
 # No instantiation, the class acts as a namespace for the shared state
 # Avoid global scope pollution and maintain consistency with the rest of the codebase
@@ -49,7 +57,8 @@ class TelemetryPacker:
 
     _TM_AVAILABLE = False
 
-    _TM_FRAME_SIZE = const(248)  # maximum allowed size of the telemetry frame
+    # Maximum allowed size of the telemetry frame
+    _TM_FRAME_SIZE = const(248)
 
     # Frame size and packet length SHALL be updated for every TM frame definition
     _FRAME = bytearray(_TM_FRAME_SIZE)  # pre-allocated buffer for packing
@@ -82,10 +91,10 @@ class TelemetryPacker:
         if not cls._TM_AVAILABLE:
             cls._TM_AVAILABLE = True
 
-        cls._FRAME = bytearray(229 + 4)  # pre-allocated buffer for packing
+        cls._FRAME = bytearray(_TM_NOMINAL_SIZE + 4)  # pre-allocated buffer for packing
         cls._FRAME[0] = const(0x01) & 0xFF  # message ID
         cls._FRAME[1:3] = pack_unsigned_short_int([const(0x00)], 0)  # sequence count
-        cls._FRAME[3] = const(229) & 0xFF  # packet length
+        cls._FRAME[3] = const(_TM_NOMINAL_SIZE) & 0xFF  # packet length
 
         ############ CDH fields ############
         if DH.data_process_exists("cdh"):
@@ -134,87 +143,82 @@ class TelemetryPacker:
                 # Battery pack SOC
                 cls._FRAME[27] = eps_data[EPS_IDX.BATTERY_PACK_REPORTED_SOC] & 0xFF
                 # Battery pack capacity
-                cls._FRAME[28:32] = pack_unsigned_long_int(eps_data, EPS_IDX.BATTERY_PACK_REPORTED_CAPACITY)
+                cls._FRAME[28:30] = pack_unsigned_short_int(eps_data, EPS_IDX.BATTERY_PACK_REPORTED_CAPACITY)
                 # Battery pack current
-                cls._FRAME[32:34] = pack_signed_short_int(eps_data, EPS_IDX.BATTERY_PACK_CURRENT)
+                cls._FRAME[30:32] = pack_signed_short_int(eps_data, EPS_IDX.BATTERY_PACK_CURRENT)
                 # Battery pack voltage
-                cls._FRAME[34:36] = pack_signed_short_int(eps_data, EPS_IDX.BATTERY_PACK_VOLTAGE)
+                cls._FRAME[32:34] = pack_signed_short_int(eps_data, EPS_IDX.BATTERY_PACK_VOLTAGE)
                 # Battery pack midpoint voltage
-                cls._FRAME[36:38] = pack_signed_short_int(eps_data, EPS_IDX.BATTERY_PACK_MIDPOINT_VOLTAGE)
+                cls._FRAME[34:36] = pack_signed_short_int(eps_data, EPS_IDX.BATTERY_PACK_MIDPOINT_VOLTAGE)
                 # Battery pack TTE
-                cls._FRAME[38:42] = pack_unsigned_long_int(eps_data, EPS_IDX.BATTERY_PACK_TTE)
+                cls._FRAME[36:40] = pack_unsigned_long_int(eps_data, EPS_IDX.BATTERY_PACK_TTE)
                 # Battery pack TTF
-                cls._FRAME[42:46] = pack_unsigned_long_int(eps_data, EPS_IDX.BATTERY_PACK_TTF)
+                cls._FRAME[40:44] = pack_unsigned_long_int(eps_data, EPS_IDX.BATTERY_PACK_TTF)
 
                 # XP coil voltage
-                cls._FRAME[46:48] = pack_signed_short_int(eps_data, EPS_IDX.XP_COIL_VOLTAGE)
+                cls._FRAME[44:46] = pack_signed_short_int(eps_data, EPS_IDX.XP_COIL_VOLTAGE)
                 # XP coil current
-                cls._FRAME[48:50] = pack_signed_short_int(eps_data, EPS_IDX.XP_COIL_CURRENT)
+                cls._FRAME[46:48] = pack_signed_short_int(eps_data, EPS_IDX.XP_COIL_CURRENT)
                 # XM coil voltage
-                cls._FRAME[50:52] = pack_signed_short_int(eps_data, EPS_IDX.XM_COIL_VOLTAGE)
+                cls._FRAME[48:50] = pack_signed_short_int(eps_data, EPS_IDX.XM_COIL_VOLTAGE)
                 # XM coil current
-                cls._FRAME[52:54] = pack_signed_short_int(eps_data, EPS_IDX.XM_COIL_CURRENT)
+                cls._FRAME[50:52] = pack_signed_short_int(eps_data, EPS_IDX.XM_COIL_CURRENT)
                 # YP coil voltage
-                cls._FRAME[54:56] = pack_signed_short_int(eps_data, EPS_IDX.YP_COIL_VOLTAGE)
+                cls._FRAME[52:54] = pack_signed_short_int(eps_data, EPS_IDX.YP_COIL_VOLTAGE)
                 # YP coil current
-                cls._FRAME[56:58] = pack_signed_short_int(eps_data, EPS_IDX.YP_COIL_CURRENT)
+                cls._FRAME[54:56] = pack_signed_short_int(eps_data, EPS_IDX.YP_COIL_CURRENT)
                 # YM coil voltage
-                cls._FRAME[58:60] = pack_signed_short_int(eps_data, EPS_IDX.YM_COIL_VOLTAGE)
+                cls._FRAME[56:58] = pack_signed_short_int(eps_data, EPS_IDX.YM_COIL_VOLTAGE)
                 # YM coil current
-                cls._FRAME[60:62] = pack_signed_short_int(eps_data, EPS_IDX.YM_COIL_CURRENT)
+                cls._FRAME[58:60] = pack_signed_short_int(eps_data, EPS_IDX.YM_COIL_CURRENT)
                 # ZP coil voltage
-                cls._FRAME[62:64] = pack_signed_short_int(eps_data, EPS_IDX.ZP_COIL_VOLTAGE)
+                cls._FRAME[60:62] = pack_signed_short_int(eps_data, EPS_IDX.ZP_COIL_VOLTAGE)
                 # ZP coil current
-                cls._FRAME[64:66] = pack_signed_short_int(eps_data, EPS_IDX.ZP_COIL_CURRENT)
+                cls._FRAME[62:64] = pack_signed_short_int(eps_data, EPS_IDX.ZP_COIL_CURRENT)
                 # ZM coil voltage
-                cls._FRAME[66:68] = pack_signed_short_int(eps_data, EPS_IDX.ZM_COIL_VOLTAGE)
+                cls._FRAME[64:66] = pack_signed_short_int(eps_data, EPS_IDX.ZM_COIL_VOLTAGE)
                 # ZM coil current
-                cls._FRAME[68:70] = pack_signed_short_int(eps_data, EPS_IDX.ZM_COIL_CURRENT)
+                cls._FRAME[66:68] = pack_signed_short_int(eps_data, EPS_IDX.ZM_COIL_CURRENT)
 
                 # Jetson input voltage
-                cls._FRAME[70:72] = pack_signed_short_int(eps_data, EPS_IDX.JETSON_INPUT_VOLTAGE)
+                cls._FRAME[68:70] = pack_signed_short_int(eps_data, EPS_IDX.JETSON_INPUT_VOLTAGE)
                 # Jetson input current
-                cls._FRAME[72:74] = pack_signed_short_int(eps_data, EPS_IDX.JETSON_INPUT_CURRENT)
+                cls._FRAME[70:72] = pack_signed_short_int(eps_data, EPS_IDX.JETSON_INPUT_CURRENT)
 
                 # RF LDO output voltage
-                cls._FRAME[74:76] = pack_signed_short_int(eps_data, EPS_IDX.RF_LDO_OUTPUT_VOLTAGE)
+                cls._FRAME[72:74] = pack_signed_short_int(eps_data, EPS_IDX.RF_LDO_OUTPUT_VOLTAGE)
                 # RF LDO output current
-                cls._FRAME[76:78] = pack_signed_short_int(eps_data, EPS_IDX.RF_LDO_OUTPUT_CURRENT)
+                cls._FRAME[74:76] = pack_signed_short_int(eps_data, EPS_IDX.RF_LDO_OUTPUT_CURRENT)
 
                 # GPS voltage
-                cls._FRAME[78:80] = pack_signed_short_int(eps_data, EPS_IDX.GPS_VOLTAGE)
+                cls._FRAME[76:78] = pack_signed_short_int(eps_data, EPS_IDX.GPS_VOLTAGE)
                 # GPS current
-                cls._FRAME[80:82] = pack_signed_short_int(eps_data, EPS_IDX.GPS_CURRENT)
+                cls._FRAME[78:80] = pack_signed_short_int(eps_data, EPS_IDX.GPS_CURRENT)
 
                 # XP solar charge voltage
-                cls._FRAME[82:84] = pack_signed_short_int(eps_data, EPS_IDX.XP_SOLAR_CHARGE_VOLTAGE)
+                cls._FRAME[80:82] = pack_signed_short_int(eps_data, EPS_IDX.XP_SOLAR_CHARGE_VOLTAGE)
                 # XP solar charge current
-                cls._FRAME[84:86] = pack_signed_short_int(eps_data, EPS_IDX.XP_SOLAR_CHARGE_CURRENT)
+                cls._FRAME[82:84] = pack_signed_short_int(eps_data, EPS_IDX.XP_SOLAR_CHARGE_CURRENT)
                 # XM solar charge voltage
-                cls._FRAME[86:88] = pack_signed_short_int(eps_data, EPS_IDX.XM_SOLAR_CHARGE_VOLTAGE)
+                cls._FRAME[84:86] = pack_signed_short_int(eps_data, EPS_IDX.XM_SOLAR_CHARGE_VOLTAGE)
                 # XM solar charge current
-                cls._FRAME[88:90] = pack_signed_short_int(eps_data, EPS_IDX.XM_SOLAR_CHARGE_CURRENT)
+                cls._FRAME[86:88] = pack_signed_short_int(eps_data, EPS_IDX.XM_SOLAR_CHARGE_CURRENT)
                 # YP solar charge voltage
-                cls._FRAME[90:92] = pack_signed_short_int(eps_data, EPS_IDX.YP_SOLAR_CHARGE_VOLTAGE)
+                cls._FRAME[88:90] = pack_signed_short_int(eps_data, EPS_IDX.YP_SOLAR_CHARGE_VOLTAGE)
                 # YP solar charge current
-                cls._FRAME[92:94] = pack_signed_short_int(eps_data, EPS_IDX.YP_SOLAR_CHARGE_CURRENT)
+                cls._FRAME[90:92] = pack_signed_short_int(eps_data, EPS_IDX.YP_SOLAR_CHARGE_CURRENT)
                 # YM solar charge voltage
-                cls._FRAME[94:96] = pack_signed_short_int(eps_data, EPS_IDX.YM_SOLAR_CHARGE_VOLTAGE)
+                cls._FRAME[92:94] = pack_signed_short_int(eps_data, EPS_IDX.YM_SOLAR_CHARGE_VOLTAGE)
                 # YM solar charge current
-                cls._FRAME[96:98] = pack_signed_short_int(eps_data, EPS_IDX.YM_SOLAR_CHARGE_CURRENT)
+                cls._FRAME[94:96] = pack_signed_short_int(eps_data, EPS_IDX.YM_SOLAR_CHARGE_CURRENT)
                 # ZP solar charge voltage
-                cls._FRAME[98:100] = pack_signed_short_int(eps_data, EPS_IDX.ZP_SOLAR_CHARGE_VOLTAGE)
+                cls._FRAME[96:98] = pack_signed_short_int(eps_data, EPS_IDX.ZP_SOLAR_CHARGE_VOLTAGE)
                 # ZP solar charge current
-                cls._FRAME[100:102] = pack_signed_short_int(eps_data, EPS_IDX.ZP_SOLAR_CHARGE_CURRENT)
+                cls._FRAME[98:100] = pack_signed_short_int(eps_data, EPS_IDX.ZP_SOLAR_CHARGE_CURRENT)
                 # ZM solar charge voltage
-                cls._FRAME[102:104] = pack_signed_short_int(eps_data, EPS_IDX.ZM_SOLAR_CHARGE_VOLTAGE)
+                cls._FRAME[100:102] = pack_signed_short_int(eps_data, EPS_IDX.ZM_SOLAR_CHARGE_VOLTAGE)
                 # ZM solar charge current
-                cls._FRAME[104:106] = pack_signed_short_int(eps_data, EPS_IDX.ZM_SOLAR_CHARGE_CURRENT)
-
-            else:
-                logger.warning("No latest EPS data available")
-        else:
-            logger.warning("No EPS data available")
+                cls._FRAME[102:104] = pack_signed_short_int(eps_data, EPS_IDX.ZM_SOLAR_CHARGE_CURRENT)
 
         ############ ADCS fields ############
         if DH.data_process_exists("adcs"):
@@ -222,70 +226,70 @@ class TelemetryPacker:
 
             if adcs_data:
                 # ADCS state
-                cls._FRAME[106] = adcs_data[ADCS_IDX.MODE] & 0xFF
+                cls._FRAME[104] = adcs_data[ADCS_IDX.MODE] & 0xFF
 
                 # Gyro X
-                cls._FRAME[107:111] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.GYRO_X])
+                cls._FRAME[105:109] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.GYRO_X])
                 # Gyro Y
-                cls._FRAME[111:115] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.GYRO_Y])
+                cls._FRAME[109:113] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.GYRO_Y])
                 # Gyro Z
-                cls._FRAME[115:119] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.GYRO_Z])
+                cls._FRAME[113:117] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.GYRO_Z])
 
                 # Magnetometer X
-                cls._FRAME[119:123] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.MAG_X])
+                cls._FRAME[117:121] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.MAG_X])
                 # Magnetometer Y
-                cls._FRAME[123:127] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.MAG_Y])
+                cls._FRAME[121:125] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.MAG_Y])
                 # Magnetometer Z
-                cls._FRAME[127:131] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.MAG_Z])
+                cls._FRAME[125:129] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.MAG_Z])
 
                 # Sun status
-                cls._FRAME[131] = adcs_data[ADCS_IDX.SUN_STATUS] & 0xFF
+                cls._FRAME[129] = adcs_data[ADCS_IDX.SUN_STATUS] & 0xFF
                 # Sun vector X
-                cls._FRAME[132:136] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.SUN_VEC_X])
+                cls._FRAME[130:134] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.SUN_VEC_X])
                 # Sun vector Y
-                cls._FRAME[136:140] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.SUN_VEC_Y])
+                cls._FRAME[134:138] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.SUN_VEC_Y])
                 # Sun vector Z
-                cls._FRAME[140:144] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.SUN_VEC_Z])
+                cls._FRAME[138:142] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.SUN_VEC_Z])
                 # Light sensor X+
-                cls._FRAME[144:146] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_XP)
+                cls._FRAME[142:144] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_XP)
                 # Light sensor X-
-                cls._FRAME[146:148] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_XM)
+                cls._FRAME[144:146] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_XM)
                 # Light sensor Y+
-                cls._FRAME[148:150] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_YP)
+                cls._FRAME[146:148] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_YP)
                 # Light sensor Y-
-                cls._FRAME[150:152] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_YM)
+                cls._FRAME[148:150] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_YM)
                 # Light sensor Z+ 1
-                cls._FRAME[152:154] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_ZP1)
+                cls._FRAME[150:152] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_ZP1)
                 # Light sensor Z+ 2
-                cls._FRAME[154:156] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_ZP2)
+                cls._FRAME[152:154] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_ZP2)
                 # Light sensor Z+ 3
-                cls._FRAME[156:158] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_ZP3)
+                cls._FRAME[154:156] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_ZP3)
                 # Light sensor Z+ 4
-                cls._FRAME[158:160] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_ZP4)
+                cls._FRAME[156:158] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_ZP4)
                 # Light sensor Z-
-                cls._FRAME[160:162] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_ZM)
+                cls._FRAME[158:160] = pack_unsigned_short_int(adcs_data, ADCS_IDX.LIGHT_SENSOR_ZM)
 
                 # XP coil status
-                cls._FRAME[162] = adcs_data[ADCS_IDX.XP_COIL_STATUS] & 0xFF
+                cls._FRAME[160] = adcs_data[ADCS_IDX.XP_COIL_STATUS] & 0xFF
                 # XM coil status
-                cls._FRAME[163] = adcs_data[ADCS_IDX.XM_COIL_STATUS] & 0xFF
+                cls._FRAME[161] = adcs_data[ADCS_IDX.XM_COIL_STATUS] & 0xFF
                 # YP coil status
-                cls._FRAME[164] = adcs_data[ADCS_IDX.YP_COIL_STATUS] & 0xFF
+                cls._FRAME[162] = adcs_data[ADCS_IDX.YP_COIL_STATUS] & 0xFF
                 # YM coil status
-                cls._FRAME[165] = adcs_data[ADCS_IDX.YM_COIL_STATUS] & 0xFF
+                cls._FRAME[163] = adcs_data[ADCS_IDX.YM_COIL_STATUS] & 0xFF
                 # ZP coil status
-                cls._FRAME[166] = adcs_data[ADCS_IDX.ZP_COIL_STATUS] & 0xFF
+                cls._FRAME[164] = adcs_data[ADCS_IDX.ZP_COIL_STATUS] & 0xFF
                 # ZM coil status
-                cls._FRAME[167] = adcs_data[ADCS_IDX.ZM_COIL_STATUS] & 0xFF
+                cls._FRAME[165] = adcs_data[ADCS_IDX.ZM_COIL_STATUS] & 0xFF
 
                 # Coarse attitude QW
-                cls._FRAME[168:172] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.ATTITUDE_QW])
+                cls._FRAME[166:170] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.ATTITUDE_QW])
                 # Coarse attitude QX
-                cls._FRAME[172:176] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.ATTITUDE_QX])
+                cls._FRAME[170:174] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.ATTITUDE_QX])
                 # Coarse attitude QY
-                cls._FRAME[176:180] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.ATTITUDE_QY])
+                cls._FRAME[174:178] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.ATTITUDE_QY])
                 # Coarse attitude QZ
-                cls._FRAME[180:184] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.ATTITUDE_QZ])
+                cls._FRAME[178:182] = convert_float_to_fixed_point_hp(adcs_data[ADCS_IDX.ATTITUDE_QZ])
 
             else:
                 logger.warning("No latest ADCS data available")
@@ -298,35 +302,35 @@ class TelemetryPacker:
 
             if gps_data:
                 # message ID
-                cls._FRAME[184] = gps_data[GPS_IDX.GPS_MESSAGE_ID] & 0xFF
+                cls._FRAME[182] = gps_data[GPS_IDX.GPS_MESSAGE_ID] & 0xFF
                 # fix mode
-                cls._FRAME[185] = gps_data[GPS_IDX.GPS_FIX_MODE] & 0xFF
+                cls._FRAME[183] = gps_data[GPS_IDX.GPS_FIX_MODE] & 0xFF
                 # number of SV
-                cls._FRAME[186] = gps_data[GPS_IDX.GPS_NUMBER_OF_SV] & 0xFF
+                cls._FRAME[184] = gps_data[GPS_IDX.GPS_NUMBER_OF_SV] & 0xFF
                 # GNSS week
-                cls._FRAME[187:189] = pack_unsigned_short_int(gps_data, GPS_IDX.GPS_GNSS_WEEK)
+                cls._FRAME[185:187] = pack_unsigned_short_int(gps_data, GPS_IDX.GPS_GNSS_WEEK)
                 # GNSS TOW
-                cls._FRAME[189:193] = pack_unsigned_long_int(gps_data, GPS_IDX.GPS_GNSS_TOW)
+                cls._FRAME[187:191] = pack_unsigned_long_int(gps_data, GPS_IDX.GPS_GNSS_TOW)
                 # latitude
-                cls._FRAME[193:197] = pack_signed_long_int(gps_data, GPS_IDX.GPS_LATITUDE)
+                cls._FRAME[191:195] = pack_signed_long_int(gps_data, GPS_IDX.GPS_LATITUDE)
                 # longitude
-                cls._FRAME[197:201] = pack_signed_long_int(gps_data, GPS_IDX.GPS_LONGITUDE)
+                cls._FRAME[195:199] = pack_signed_long_int(gps_data, GPS_IDX.GPS_LONGITUDE)
                 # ellipsoid altitude
-                cls._FRAME[201:205] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ELLIPSOID_ALT)
+                cls._FRAME[199:203] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ELLIPSOID_ALT)
                 # mean sea level altitude
-                cls._FRAME[205:209] = pack_signed_long_int(gps_data, GPS_IDX.GPS_MEAN_SEA_LVL_ALT)
+                cls._FRAME[203:207] = pack_signed_long_int(gps_data, GPS_IDX.GPS_MEAN_SEA_LVL_ALT)
                 # ECEF X
-                cls._FRAME[209:213] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_X)
+                cls._FRAME[207:211] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_X)
                 # ECEF Y
-                cls._FRAME[213:217] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_Y)
+                cls._FRAME[211:215] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_Y)
                 # ECEF Z
-                cls._FRAME[217:221] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_Z)
+                cls._FRAME[215:219] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_Z)
                 # ECEF VX
-                cls._FRAME[221:225] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_VX)
+                cls._FRAME[219:223] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_VX)
                 # ECEF VY
-                cls._FRAME[225:229] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_VY)
+                cls._FRAME[223:227] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_VY)
                 # ECEF VZ
-                cls._FRAME[229:233] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_VZ)
+                cls._FRAME[227:231] = pack_signed_long_int(gps_data, GPS_IDX.GPS_ECEF_VZ)
             else:
                 logger.warning("No latest GPS data available")
         else:
@@ -347,10 +351,10 @@ class TelemetryPacker:
             cls._TM_AVAILABLE = True
 
         # TODO: Frame definition for TM_HAL
-        cls._FRAME = bytearray(14 + 4)  # pre-allocated buffer for packing
+        cls._FRAME = bytearray(_TM_HAL_SIZE + 4)  # pre-allocated buffer for packing
         cls._FRAME[0] = const(0x02) & 0xFF  # message ID
         cls._FRAME[1:3] = pack_unsigned_short_int([const(0x00)], 0)  # sequence count
-        cls._FRAME[3] = const(14) & 0xFF  # packet length
+        cls._FRAME[3] = const(_TM_HAL_SIZE) & 0xFF  # packet length
 
         ############ CDH fields ############
         if DH.data_process_exists("cdh"):
@@ -386,10 +390,10 @@ class TelemetryPacker:
         if not cls._TM_AVAILABLE:
             cls._TM_AVAILABLE = True
 
-        cls._FRAME = bytearray(74 + 4)  # pre-allocated buffer for packing
+        cls._FRAME = bytearray(_TM_STORAGE_SIZE + 4)  # pre-allocated buffer for packing
         cls._FRAME[0] = const(0x03) & 0xFF  # message ID
         cls._FRAME[1:3] = pack_unsigned_short_int([const(0x00)], 0)  # sequence count
-        cls._FRAME[3] = const(74) & 0xFF  # packet length
+        cls._FRAME[3] = const(_TM_STORAGE_SIZE) & 0xFF  # packet length
 
         ############ CDH fields ############
         if DH.data_process_exists("cdh"):

--- a/flight/apps/telemetry/packing.py
+++ b/flight/apps/telemetry/packing.py
@@ -49,12 +49,13 @@ class TelemetryPacker:
 
     _TM_AVAILABLE = False
 
-    _TM_FRAME_SIZE = const(248)  # size of the telemetry frame
+    _TM_FRAME_SIZE = const(248)  # maximum allowed size of the telemetry frame
 
+    # Frame size and packet length SHALL be updated for every TM frame definition
     _FRAME = bytearray(_TM_FRAME_SIZE)  # pre-allocated buffer for packing
     _FRAME[0] = const(0x01) & 0xFF  # message ID
     _FRAME[1:3] = pack_unsigned_short_int([const(0x00)], 0)  # sequence count
-    _FRAME[3] = const(229) & 0xFF  # packet length
+    _FRAME[3] = const(_TM_FRAME_SIZE) & 0xFF  # packet length
 
     @classmethod
     def FRAME(cls):
@@ -81,10 +82,10 @@ class TelemetryPacker:
         if not cls._TM_AVAILABLE:
             cls._TM_AVAILABLE = True
 
-        cls._FRAME = bytearray(227 + 4)  # pre-allocated buffer for packing
+        cls._FRAME = bytearray(229 + 4)  # pre-allocated buffer for packing
         cls._FRAME[0] = const(0x01) & 0xFF  # message ID
         cls._FRAME[1:3] = pack_unsigned_short_int([const(0x00)], 0)  # sequence count
-        cls._FRAME[3] = const(227) & 0xFF  # packet length
+        cls._FRAME[3] = const(229) & 0xFF  # packet length
 
         ############ CDH fields ############
         if DH.data_process_exists("cdh"):

--- a/flight/apps/telemetry/packing.py
+++ b/flight/apps/telemetry/packing.py
@@ -347,10 +347,10 @@ class TelemetryPacker:
             cls._TM_AVAILABLE = True
 
         # TODO: Frame definition for TM_HAL
-        cls._FRAME = bytearray(13 + 4)  # pre-allocated buffer for packing
+        cls._FRAME = bytearray(14 + 4)  # pre-allocated buffer for packing
         cls._FRAME[0] = const(0x02) & 0xFF  # message ID
         cls._FRAME[1:3] = pack_unsigned_short_int([const(0x00)], 0)  # sequence count
-        cls._FRAME[3] = const(13) & 0xFF  # packet length
+        cls._FRAME[3] = const(14) & 0xFF  # packet length
 
         ############ CDH fields ############
         if DH.data_process_exists("cdh"):
@@ -386,10 +386,10 @@ class TelemetryPacker:
         if not cls._TM_AVAILABLE:
             cls._TM_AVAILABLE = True
 
-        cls._FRAME = bytearray(72 + 4)  # pre-allocated buffer for packing
+        cls._FRAME = bytearray(82 + 4)  # pre-allocated buffer for packing
         cls._FRAME[0] = const(0x03) & 0xFF  # message ID
         cls._FRAME[1:3] = pack_unsigned_short_int([const(0x00)], 0)  # sequence count
-        cls._FRAME[3] = const(72) & 0xFF  # packet length
+        cls._FRAME[3] = const(82) & 0xFF  # packet length
 
         ############ CDH fields ############
         if DH.data_process_exists("cdh"):
@@ -420,15 +420,15 @@ class TelemetryPacker:
             logger.warning("No CDH data available")
 
         # Total SD card usage
-        cls._FRAME[18:22] = pack_signed_long_int([DH.SD_usage()], 0)
+        cls._FRAME[18:22] = pack_unsigned_long_int([DH.SD_usage()], 0)
 
         ############ CDH fields ###########
         if DH.data_process_exists("cdh"):
             cdh_storage_info = DH.get_storage_info("cdh")
             # CDH number of files
-            cls._FRAME[22:26] = pack_signed_long_int(cdh_storage_info, STORAGE_IDX.NUM_FILES)
+            cls._FRAME[22:26] = pack_unsigned_long_int(cdh_storage_info, STORAGE_IDX.NUM_FILES)
             # CDH directory size
-            cls._FRAME[26:30] = pack_signed_long_int(cdh_storage_info, STORAGE_IDX.DIR_SIZE)
+            cls._FRAME[26:30] = pack_unsigned_long_int(cdh_storage_info, STORAGE_IDX.DIR_SIZE)
         else:
             logger.warning("CDH Data process does not exist")
 
@@ -436,9 +436,9 @@ class TelemetryPacker:
         if DH.data_process_exists("eps"):
             eps_storage_info = DH.get_storage_info("eps")
             # EPS number of files
-            cls._FRAME[30:34] = pack_signed_long_int(eps_storage_info, STORAGE_IDX.NUM_FILES)
+            cls._FRAME[30:34] = pack_unsigned_long_int(eps_storage_info, STORAGE_IDX.NUM_FILES)
             # EPS directory size
-            cls._FRAME[34:38] = pack_signed_long_int(eps_storage_info, STORAGE_IDX.DIR_SIZE)
+            cls._FRAME[34:38] = pack_unsigned_long_int(eps_storage_info, STORAGE_IDX.DIR_SIZE)
         else:
             logger.warning("EPS Data process does not exist")
 
@@ -446,9 +446,9 @@ class TelemetryPacker:
         if DH.data_process_exists("adcs"):
             adcs_storage_info = DH.get_storage_info("adcs")
             # ADCS number of files
-            cls._FRAME[38:42] = pack_signed_long_int(adcs_storage_info, STORAGE_IDX.NUM_FILES)
+            cls._FRAME[38:42] = pack_unsigned_long_int(adcs_storage_info, STORAGE_IDX.NUM_FILES)
             # ADCS directory size
-            cls._FRAME[42:46] = pack_signed_long_int(adcs_storage_info, STORAGE_IDX.DIR_SIZE)
+            cls._FRAME[42:46] = pack_unsigned_long_int(adcs_storage_info, STORAGE_IDX.DIR_SIZE)
         else:
             logger.warning("ADCS Data process does not exist")
 
@@ -456,9 +456,9 @@ class TelemetryPacker:
         if DH.data_process_exists("comms"):
             comms_storage_info = DH.get_storage_info("comms")
             # COMMS number of files
-            cls._FRAME[46:50] = pack_signed_long_int(comms_storage_info, STORAGE_IDX.NUM_FILES)
+            cls._FRAME[46:50] = pack_unsigned_long_int(comms_storage_info, STORAGE_IDX.NUM_FILES)
             # COMMS directory size
-            cls._FRAME[50:54] = pack_signed_long_int(comms_storage_info, STORAGE_IDX.DIR_SIZE)
+            cls._FRAME[50:54] = pack_unsigned_long_int(comms_storage_info, STORAGE_IDX.DIR_SIZE)
         else:
             logger.warning("Comms Data process does not exist")
 
@@ -466,9 +466,9 @@ class TelemetryPacker:
         if DH.data_process_exists("gps"):
             gps_storage_info = DH.get_storage_info("gps")
             # GPS number of files
-            cls._FRAME[54:58] = pack_signed_long_int(gps_storage_info, STORAGE_IDX.NUM_FILES)
+            cls._FRAME[54:58] = pack_unsigned_long_int(gps_storage_info, STORAGE_IDX.NUM_FILES)
             # GPS directory size
-            cls._FRAME[58:62] = pack_signed_long_int(gps_storage_info, STORAGE_IDX.DIR_SIZE)
+            cls._FRAME[58:62] = pack_unsigned_long_int(gps_storage_info, STORAGE_IDX.DIR_SIZE)
         else:
             logger.warning("GPS Data process does not exist")
 
@@ -476,9 +476,9 @@ class TelemetryPacker:
         if DH.data_process_exists("payload"):
             payload_storage_info = DH.get_storage_info("payload")
             # PAYLOAD number of files
-            cls._FRAME[62:66] = pack_signed_long_int(payload_storage_info, STORAGE_IDX.NUM_FILES)
+            cls._FRAME[62:66] = pack_unsigned_long_int(payload_storage_info, STORAGE_IDX.NUM_FILES)
             # PAYLOAD directory size
-            cls._FRAME[66:70] = pack_signed_long_int(payload_storage_info, STORAGE_IDX.DIR_SIZE)
+            cls._FRAME[66:70] = pack_unsigned_long_int(payload_storage_info, STORAGE_IDX.DIR_SIZE)
         else:
             logger.warning("Payload Data process does not exist")
 
@@ -486,9 +486,9 @@ class TelemetryPacker:
         if DH.data_process_exists("thermal"):
             thermal_storage_info = DH.get_storage_info("thermal")
             # THERMAL number of files
-            cls._FRAME[70:74] = pack_signed_long_int(thermal_storage_info, STORAGE_IDX.NUM_FILES)
+            cls._FRAME[70:74] = pack_unsigned_long_int(thermal_storage_info, STORAGE_IDX.NUM_FILES)
             # THERMAL directory size
-            cls._FRAME[74:78] = pack_signed_long_int(thermal_storage_info, STORAGE_IDX.DIR_SIZE)
+            cls._FRAME[74:78] = pack_unsigned_long_int(thermal_storage_info, STORAGE_IDX.DIR_SIZE)
         else:
             logger.warning("Thermal Data process does not exist")
 
@@ -496,9 +496,9 @@ class TelemetryPacker:
         if DH.data_process_exists("cmd_logs"):
             cmd_logs_storage_info = DH.get_storage_info("cmd_logs")
             # Command logs number of files
-            cls._FRAME[78:82] = pack_signed_long_int(cmd_logs_storage_info, STORAGE_IDX.NUM_FILES)
+            cls._FRAME[78:82] = pack_unsigned_long_int(cmd_logs_storage_info, STORAGE_IDX.NUM_FILES)
             # Command logs directory size
-            cls._FRAME[82:86] = pack_signed_long_int(cmd_logs_storage_info, STORAGE_IDX.DIR_SIZE)
+            cls._FRAME[82:86] = pack_unsigned_long_int(cmd_logs_storage_info, STORAGE_IDX.DIR_SIZE)
         else:
             logger.warning("Command logs Data process does not exist")
 

--- a/flight/apps/telemetry/packing.py
+++ b/flight/apps/telemetry/packing.py
@@ -386,10 +386,10 @@ class TelemetryPacker:
         if not cls._TM_AVAILABLE:
             cls._TM_AVAILABLE = True
 
-        cls._FRAME = bytearray(82 + 4)  # pre-allocated buffer for packing
+        cls._FRAME = bytearray(74 + 4)  # pre-allocated buffer for packing
         cls._FRAME[0] = const(0x03) & 0xFF  # message ID
         cls._FRAME[1:3] = pack_unsigned_short_int([const(0x00)], 0)  # sequence count
-        cls._FRAME[3] = const(82) & 0xFF  # packet length
+        cls._FRAME[3] = const(74) & 0xFF  # packet length
 
         ############ CDH fields ############
         if DH.data_process_exists("cdh"):
@@ -482,35 +482,15 @@ class TelemetryPacker:
         else:
             logger.warning("Payload Data process does not exist")
 
-        ############ Thermal fields ###########
-        if DH.data_process_exists("thermal"):
-            thermal_storage_info = DH.get_storage_info("thermal")
-            # THERMAL number of files
-            cls._FRAME[70:74] = pack_unsigned_long_int(thermal_storage_info, STORAGE_IDX.NUM_FILES)
-            # THERMAL directory size
-            cls._FRAME[74:78] = pack_unsigned_long_int(thermal_storage_info, STORAGE_IDX.DIR_SIZE)
-        else:
-            logger.warning("Thermal Data process does not exist")
-
         ############ Command fields ###########
         if DH.data_process_exists("cmd_logs"):
             cmd_logs_storage_info = DH.get_storage_info("cmd_logs")
             # Command logs number of files
-            cls._FRAME[78:82] = pack_unsigned_long_int(cmd_logs_storage_info, STORAGE_IDX.NUM_FILES)
+            cls._FRAME[70:74] = pack_unsigned_long_int(cmd_logs_storage_info, STORAGE_IDX.NUM_FILES)
             # Command logs directory size
-            cls._FRAME[82:86] = pack_unsigned_long_int(cmd_logs_storage_info, STORAGE_IDX.DIR_SIZE)
+            cls._FRAME[74:78] = pack_unsigned_long_int(cmd_logs_storage_info, STORAGE_IDX.DIR_SIZE)
         else:
             logger.warning("Command logs Data process does not exist")
-
-        # ############ Image fields ###########
-        # if DH.data_process_exists("img"):
-        #     img_logs_storage_info = DH.get_storage_info("img")
-        #     # Image number of files
-        #     cls._FRAME[86:90] = pack_signed_long_int(img_logs_storage_info, STORAGE_IDX.NUM_FILES)
-        #     # Image directory size
-        #     cls._FRAME[90:94] = pack_signed_long_int(img_logs_storage_info, STORAGE_IDX.DIR_SIZE)
-        # else:
-        #     logger.warning("IMG Data process does not exist")
 
     @classmethod
     def pack_tm_payload(cls):

--- a/flight/core/data_handler.py
+++ b/flight/core/data_handler.py
@@ -510,7 +510,11 @@ class DataProcess:
         """
         files = os.listdir(self.dir_path)
         # TODO - implement the rest of the function
-        total_size = (len(files) - 2) * self.size_limit + self.get_current_file_size()
+        if self.get_current_file_size() is not None:
+            total_size = (len(files) - 2) * self.size_limit + self.get_current_file_size()
+        else:
+            total_size = 0
+
         return (len(files) - 1), total_size
 
     def get_current_file_size(self) -> Optional[int]:

--- a/flight/core/template_task.py
+++ b/flight/core/template_task.py
@@ -53,7 +53,7 @@ class TemplateTask:
             await self.main_task()
             gc.collect()
         except Exception as e:
-            self.debug(e, traceback.format_exc())
+            self.debug(e, "".join(traceback.format_exception(e)))
 
     def log_debug(self, msg):
         """

--- a/flight/hal/cubesat.py
+++ b/flight/hal/cubesat.py
@@ -24,7 +24,7 @@ class CubeSat:
         self.__device_list = OrderedDict(
             [
                 ("SDCARD", Device(self.__sd_card_boot)),
-                # ("IMU", Device(self.__imu_boot)),
+                ("IMU", Device(self.__imu_boot)),
                 ("RTC", Device(self.__rtc_boot)),
                 ("GPS", Device(self.__gps_boot)),
                 ("RADIO", Device(self.__radio_boot)),

--- a/flight/hal/cubesat.py
+++ b/flight/hal/cubesat.py
@@ -20,8 +20,8 @@ class CubeSat:
         "_time_ref_boot",
     )
 
-    def __new__(cls, *args, **kwargs):
-        raise TypeError(f"{cls.__name__} is a static base class and cannot be instantiated.")
+    # def __new__(cls, *args, **kwargs):
+    #     raise TypeError(f"{cls.__name__} is a static base class and cannot be instantiated.")
 
     def __init__(self):
         self.__device_list = OrderedDict(

--- a/flight/hal/cubesat.py
+++ b/flight/hal/cubesat.py
@@ -24,7 +24,7 @@ class CubeSat:
         self.__device_list = OrderedDict(
             [
                 ("SDCARD", Device(self.__sd_card_boot)),
-                ("IMU", Device(self.__imu_boot)),
+                # ("IMU", Device(self.__imu_boot)),
                 ("RTC", Device(self.__rtc_boot)),
                 ("GPS", Device(self.__gps_boot)),
                 ("RADIO", Device(self.__radio_boot)),

--- a/flight/hal/cubesat.py
+++ b/flight/hal/cubesat.py
@@ -20,8 +20,8 @@ class CubeSat:
         "_time_ref_boot",
     )
 
-    # def __new__(cls, *args, **kwargs):
-    #     raise TypeError(f"{cls.__name__} is a static base class and cannot be instantiated.")
+    def __new__(cls, *args, **kwargs):
+        raise TypeError(f"{cls.__name__} is a static base class and cannot be instantiated.")
 
     def __init__(self):
         self.__device_list = OrderedDict(

--- a/flight/tasks/comms.py
+++ b/flight/tasks/comms.py
@@ -26,7 +26,7 @@ class Task(TemplateTask):
         self.frequency_set = False
 
         self.TX_heartbeat_frequency = 0.2
-        self.RX_timeout_frequency = 0.5
+        self.RX_timeout_frequency = 0.1
 
         # Counter for TX frequency
         self.TX_COUNT_THRESHOLD = 0

--- a/tests/test_cmd_processor.py
+++ b/tests/test_cmd_processor.py
@@ -221,7 +221,7 @@ def test_valid_time_format():
     assert valid_time_format(1589387500)
 
     # Test edge cases and failing
-    assert valid_time_format(0)
+    assert not valid_time_format(0)  # outside of valid mission range
     assert not valid_time_format("not_a_timestamp")  # invalid type
     assert not valid_time_format(9223372036854775807)  # beyond time_t limits
     assert not valid_time_format(999999999999999999999999999999)  # far positive


### PR DESCRIPTION
Some bugs that have been caught over the last few days in testing with the GS:

- Changes to TM packing for HBs and TM STORAGE
- Comms now sets internal file ID definition based on filename
- Precondition for UPLINK TIME REFERENCE updated to use existing CPy packages, and have more mission-specific scope
- DH.get_storage_info has more error checking
- CMD Processor test for time preconditions updated to match the new precondition check