### PR TITLE
Fixes to HAL to allow for CubeSat being a base class

### DIFF
--- a/emulator/cubesat.py
+++ b/emulator/cubesat.py
@@ -15,6 +15,11 @@ class Device:
 class CubeSat:
     """CubeSat: Base class for all CubeSat implementations"""
 
+    def __new__(cls, *args, **kwargs):
+        if cls is CubeSat:
+            raise TypeError(f"{cls.__name__} is a static base class and cannot be instantiated.")
+        return super().__new__(cls)
+
     def __init__(self):
         # List of successfully initialized devices
         self._device_list = OrderedDict(

--- a/flight/hal/cubesat.py
+++ b/flight/hal/cubesat.py
@@ -21,7 +21,9 @@ class CubeSat:
     )
 
     def __new__(cls, *args, **kwargs):
-        raise TypeError(f"{cls.__name__} is a static base class and cannot be instantiated.")
+        if cls is CubeSat:
+            raise TypeError(f"{cls.__name__} is a static base class and cannot be instantiated.")
+        return super().__new__(cls)
 
     def __init__(self):
         self.__device_list = OrderedDict(


### PR DESCRIPTION
We broke main again.

This allows CubeSat to not be initialized with everything else being the same.