### PR TITLE
Fuel gauge capacity reading change

### DIFF
--- a/flight/hal/drivers/max17205.py
+++ b/flight/hal/drivers/max17205.py
@@ -77,7 +77,7 @@ class MAX17205:
             i2c.readinto(self.rx_buffer)
 
         # Convert readback bytes to pack capacity
-        self.capacity = int.from_bytes(self.rx_buffer, "little", signed=False) / 0.01
+        self.capacity = int.from_bytes(self.rx_buffer, "little", signed=False) * 0.5
 
         return self.capacity
 

--- a/flight/tasks/eps.py
+++ b/flight/tasks/eps.py
@@ -94,7 +94,7 @@ class Task(TemplateTask):
         else:
             if not DH.data_process_exists("eps"):
                 data_format = (
-                    "Lbhhhhb" + "L" + "h" * 3 + "L" * 2 + "h" * 30
+                    "Lbhhhhb" + "h" * 4 + "L" * 2 + "h" * 30
                 )  # - use mV for voltage and mA for current (h = short integer 2 bytes, L = 4 bytes)
                 DH.register_data_process("eps", data_format, True, data_limit=100000)
 


### PR DESCRIPTION
Fuel gauge capacity register was being processed incorrectly. Should just multiply raw register value by 0.5, and that value should fit in 2 bytes