### PR TITLE
ADCS: Timeout set on MEKF Initialization

### DIFF
--- a/flight/apps/adcs/consts.py
+++ b/flight/apps/adcs/consts.py
@@ -20,29 +20,30 @@ class StatusConst:
 
     # Algorithm Failures
     MEKF_INIT_FAIL = 1
-    OPROP_INIT_FAIL = 2
-    TRIAD_FAIL = 3
-    POS_UPDATE_FAIL = 4
-    SUN_UPDATE_FAIL = 5
-    MAG_UPDATE_FAIL = 6
-    EKF_UPDATE_FAIL = 7
-    TRUE_SUN_MAP_FAIL = 8
-    TRUE_MAG_MAP_FAIL = 9
+    MEKF_INIT_FORCE = 2
+    OPROP_INIT_FAIL = 3
+    TRIAD_FAIL = 4
+    POS_UPDATE_FAIL = 5
+    SUN_UPDATE_FAIL = 6
+    MAG_UPDATE_FAIL = 7
+    EKF_UPDATE_FAIL = 8
+    TRUE_SUN_MAP_FAIL = 9
+    TRUE_MAG_MAP_FAIL = 10
 
     # Sensor based Failures
     # Gyro
-    GYRO_FAIL = 11
+    GYRO_FAIL = 21
     # Magnetometer
-    MAG_FAIL = 21
+    MAG_FAIL = 31
     # GPS
-    GPS_FAIL = 31
+    GPS_FAIL = 41
     # Light Sensor
-    SUN_NO_READINGS = 41
-    SUN_NOT_ENOUGH_READINGS = 42
-    SUN_ECLIPSE = 43
+    SUN_NO_READINGS = 51
+    SUN_NOT_ENOUGH_READINGS = 52
+    SUN_ECLIPSE = 53
 
     # Misc
-    ZERO_NORM = 51
+    ZERO_NORM = 61
 
     # Success Status Constants
     OK = 0
@@ -50,6 +51,7 @@ class StatusConst:
     # Failure Messages
     _FAIL_MESSAGES = {
         MEKF_INIT_FAIL: "MEKF init failure",
+        MEKF_INIT_FORCE: "Force initializing MEKF",
         OPROP_INIT_FAIL: "Orbit Prop Init failure",
         TRIAD_FAIL: "TRIAD failure",
         POS_UPDATE_FAIL: "Position update failure",
@@ -65,6 +67,7 @@ class StatusConst:
         SUN_NOT_ENOUGH_READINGS: "Insufficient readings",
         SUN_ECLIPSE: "In eclipse",
         ZERO_NORM: "Zero-normed vector",
+        OK: "Success",
     }
 
     @classmethod

--- a/flight/tasks/adcs.py
+++ b/flight/tasks/adcs.py
@@ -117,7 +117,7 @@ class Task(TemplateTask):
                 else:
                     if not self.AD.initialized:
                         status_1, status_2 = self.AD.initialize_mekf()
-                        if status_1 != StatusConst.OK:
+                        if status_1 != StatusConst.OK or status_2 != StatusConst.OK:
                             self.failure_messages.append(
                                 StatusConst.get_fail_message(status_1) + " : " + StatusConst.get_fail_message(status_2)
                             )
@@ -172,11 +172,7 @@ class Task(TemplateTask):
                     else:
                         if not self.AD.initialized:
                             status_1, status_2 = self.AD.initialize_mekf()
-                            if status_1 != StatusConst.OK:
-                                self.failure_messages.append(
-                                    StatusConst.get_fail_message(status_1) + " : " + StatusConst.get_fail_message(status_2)
-                                )
-                            elif status_2 != StatusConst.OK:
+                            if status_1 != StatusConst.OK or status_2 != StatusConst.OK:
                                 self.failure_messages.append(
                                     StatusConst.get_fail_message(status_1) + " : " + StatusConst.get_fail_message(status_2)
                                 )

--- a/flight/tasks/adcs.py
+++ b/flight/tasks/adcs.py
@@ -176,6 +176,10 @@ class Task(TemplateTask):
                                 self.failure_messages.append(
                                     StatusConst.get_fail_message(status_1) + " : " + StatusConst.get_fail_message(status_2)
                                 )
+                            elif status_2 != StatusConst.OK:
+                                self.failure_messages.append(
+                                    StatusConst.get_fail_message(status_1) + " : " + StatusConst.get_fail_message(status_2)
+                                )
                         else:
                             # Update Each sensor with covariances
                             status_1, status_2 = self.AD.position_update(self.time)


### PR DESCRIPTION
This PR addresses the following:
- Sets a Timeout on MEKF Initialization
    - For MEKF init to work, we need valid GPS, sun sensor and magneto readings (which may not happen)
    - If any one sensor fails, MEKF init will always fail and the AD algorithm is useless
    - Now, there is a timeout and the MEKF is force initialized to a unit quaternion
    - We take a hit on the MEKF converging, but better than nothing

Tested on HW and works