### PR TITLE
CDH: Global State Machine for Argus

### DIFF
--- a/flight/hal/argus_v2.py
+++ b/flight/hal/argus_v2.py
@@ -247,7 +247,29 @@ class ArgusV2(CubeSat):
         """__init__: Initializes the Argus V2 CubeSat."""
         self.__debug = debug
 
+        # v2 mainboards have no NEOPIXEL, and limited RAM
+        # So, remove all components that do not exist on MB itself
         super().__init__()
+        del self.__device_list["NEOPIXEL"]
+
+        del self.__device_list["TORQUE_XP"]
+        del self.__device_list["TORQUE_XM"]
+        del self.__device_list["TORQUE_YP"]
+        del self.__device_list["TORQUE_YM"]
+        del self.__device_list["TORQUE_ZP"]
+        del self.__device_list["TORQUE_ZM"]
+
+        del self.__device_list["LIGHT_XP"]
+        del self.__device_list["LIGHT_XM"]
+        del self.__device_list["LIGHT_YP"]
+        del self.__device_list["LIGHT_YM"]
+        del self.__device_list["LIGHT_ZM"]
+
+        del self.__device_list["XP_PWR"]
+        del self.__device_list["XM_PWR"]
+        del self.__device_list["YP_PWR"]
+        del self.__device_list["YM_PWR"]
+        del self.__device_list["ZP_PWR"]
 
     ######################## BOOT SEQUENCE ########################
 
@@ -257,6 +279,10 @@ class ArgusV2(CubeSat):
         for name, device in self.__device_list.items():
             func = device.boot_fn
             device.device, device.error = func(name)
+
+    def __neopixel_boot(self, _) -> list[object, int]:
+        """Mock for neopixel boot from ArgusV3"""
+        pass
 
     def __gps_boot(self, _) -> list[object, int]:
 

--- a/flight/tasks/command.py
+++ b/flight/tasks/command.py
@@ -168,7 +168,7 @@ class Task(TemplateTask):
             if self.EPS_MODE == EPS_POWER_FLAG.LOW_POWER:
                 # T1.2: Low SoC, transition to low power
                 self.log_info("T1.2: Transition from DETUMBLING to LOW POWER")
-                SM.switch_to(STATES.NOMINAL)
+                SM.switch_to(STATES.LOW_POWER)
 
         # ------------------------------------------------------------------------------------------------------------------------------------
         # NOMINAL

--- a/flight/tasks/command.py
+++ b/flight/tasks/command.py
@@ -68,15 +68,16 @@ class Task(TemplateTask):
         # Check time_since_boot
         time_since_boot = TPM.monotonic() - SATELLITE.BOOTTIME
 
-        # NOTE: TPM time reference initialization
-        # In case the RTC has died, TPM uses time reference for time keeping
-        # The time reference is used to get offset from time.time()
+        """
+        In case the RTC has died, the TPM uses a time reference for time keeping
+        The time reference is used to get offset from time.time() in CPy.
 
-        # If an old time reference is not available, we depend on state correction
-        # from GPS or uplinked commands, and until then the time will be egregiously wrong
+        If an old time reference is not available, we depend on state correction
+        from GPS or uplinked commands, and until then the time will be egregiously wrong.
 
-        # This will not work until OBDH initializes CDH data process, so try for 10 seconds
-        # since the SC has booted
+        This will not work until the OBDH initializes CDH data process, so we try this
+        for _TPM_INIT_TIMEOUT seconds since the SC has booted.
+        """
 
         if time_since_boot < _TPM_INIT_TIMEOUT and SATELLITE.RTC_AVAILABLE is False and self.time_ref_set is False:
             # Only worth it if the RTC is dead
@@ -112,7 +113,7 @@ class Task(TemplateTask):
 
                 # T0: Boot over and deployment complete
                 SM.switch_to(STATES.DETUMBLING)
-                self.log_info("Switching to DETUMBLING state.")
+                self.log_info("T0: Transition from STARTUP to DETUMBLING")
 
     def state_machine_execution(self):
         # ------------------------------------------------------------------------------------------------------------------------------------

--- a/flight/tasks/command.py
+++ b/flight/tasks/command.py
@@ -140,6 +140,13 @@ class Task(TemplateTask):
 
             if adcs_data:
                 self.ADCS_MODE = adcs_data[ADCS_IDX.MODE]
+
+                if not (self.ADCS_MODE >= Modes.TUMBLING and self.ADCS_MODE <= Modes.SUN_POINTED):
+                    self.log_error("ADCS returned an invalid mode, assuming STABLE ADCS mode")
+                    self.ADCS_MODE = Modes.STABLE
+                else:
+                    # Valid mode returned by the ADCS
+                    pass
             else:
                 self.log_warning("No latest ADCS data available, assuming STABLE ADCS mode")
                 self.ADCS_MODE = Modes.STABLE
@@ -153,6 +160,13 @@ class Task(TemplateTask):
 
             if eps_data:
                 self.EPS_MODE = eps_data[EPS_IDX.EPS_POWER_FLAG]
+
+                if not (self.EPS_MODE >= EPS_POWER_FLAG.NONE and self.EPS_MODE <= EPS_POWER_FLAG.EXPERIMENT):
+                    self.log_error("EPS returned an invalid mode, assuming NOMINAL EPS mode")
+                    self.EPS_MODE = EPS_POWER_FLAG.NOMINAL
+                else:
+                    # Valid mode returned by EPS
+                    pass
             else:
                 self.log_warning("No latest EPS data available, assuming NOMINAL EPS mode")
                 self.EPS_MODE = EPS_POWER_FLAG.NOMINAL

--- a/flight/tasks/command.py
+++ b/flight/tasks/command.py
@@ -161,7 +161,7 @@ class Task(TemplateTask):
                 self.log_data[CDH_IDX.DETUMBLING_ERROR_FLAG] = 1
 
             if self.ADCS_MODE != Modes.TUMBLING or self.log_data[CDH_IDX.DETUMBLING_ERROR_FLAG] == 1:
-                # T1.1: Out of tumbling OR detumbling error flag is set (detumbling timeout)
+                # T1.1: Spin stabilized OR detumbling error flag is set (detumbling timeout)
                 self.log_info("T1.1: Transition from DETUMBLING to NOMINAL")
                 SM.switch_to(STATES.NOMINAL)
 
@@ -204,7 +204,7 @@ class Task(TemplateTask):
                 SATELLITE.NEOPIXEL.fill([255, 0, 0])
 
             if self.EPS_MODE != EPS_POWER_FLAG.LOW_POWER:
-                # T3.1: Nominal SoC, transition out of low power
+                # T3.1: Nominal or high SoC, transition out of low power
                 self.log_info("T3.1: Transition from LOW POWER to NOMINAL")
                 SM.switch_to(STATES.NOMINAL)
 
@@ -218,7 +218,7 @@ class Task(TemplateTask):
                 SATELLITE.NEOPIXEL.fill([255, 0, 255])
 
             if self.EPS_MODE != EPS_POWER_FLAG.EXPERIMENT:
-                # T4.1: Nominal SoC, transition back to nominal
+                # T4.1: Nominal or low SoC, transition back to nominal
                 self.log_info("T4.1: Transition from LOW POWER to NOMINAL")
                 SM.switch_to(STATES.NOMINAL)
 


### PR DESCRIPTION
Globalized state machine implementation for Argus' currently planned states:
- Adds all transitions in state machine (fig. below)
- FSW logs have label for all state transitions
- All state transitions based on modes from ADCS (angular velocity) and EPS (battery SoC)

![Argus State Machine drawio](https://github.com/user-attachments/assets/4fc38f46-75dc-45b7-8c34-71e312a40fc1)

Additionally, for HAL v2, all peripherals not present on the MB are removed. This reduces RAM use for these boards by around 5%. Not everyone in the lab has v3 MBs yet so it's something we need to do (main now exceeds RAM threshold for v2 mainboards).