### PR TITLE
default watchdog input to high on init

### DIFF
--- a/flight/hal/drivers/watchdog.py
+++ b/flight/hal/drivers/watchdog.py
@@ -9,7 +9,7 @@ class Watchdog:
 
         self.__input = digitalio.DigitalInOut(input)
         self.__input.direction = digitalio.Direction.OUTPUT
-        self.__input.value = False
+        self.__input.value = True
 
     def enable(self):
         self.__enable.value = True


### PR DESCRIPTION
New watchdog detects falling edge instead of rising edge. defaulting to high to allow first edge to reset watchdog window