### PR TITLE
disabling the coils in Low Power Mode or when ADCS objective is achieved

### DIFF
--- a/emulator/cubesat.py
+++ b/emulator/cubesat.py
@@ -28,6 +28,7 @@ class Device:
         self.error_count = 0
         self.peripheral_line = peripheral_line
         self.dead = False
+        self.temp_disabled = False
 
 
 class CubeSat:
@@ -225,7 +226,12 @@ class CubeSat:
         :param dir: The direction key (e.g., 'XP', 'XM', etc.)
         :return: bool - True if the driver exists and is not None, False otherwise.
         """
-        return self.key_in_device_list("TORQUE_" + dir) and self.__device_list["TORQUE_" + dir].device is not None
+        return (
+            self.key_in_device_list("TORQUE_" + dir)
+            and self.__device_list["TORQUE_" + dir].device is not None
+            and not self.__device_list["TORQUE_" + dir].dead
+            and not self.__device_list["TORQUE_" + dir].temp_disabled
+        )
 
     def TORQUE_DRIVERS_CURRENT(self, dir: str) -> float:
         """Returns the coil current for the specific magnetorquer if available and returns -1 otherwise

--- a/emulator/cubesat.py
+++ b/emulator/cubesat.py
@@ -233,6 +233,21 @@ class CubeSat:
             and not self.__device_list["TORQUE_" + dir].temp_disabled
         )
 
+    def TORQUE_DRIVERS_NOT_DEAD(self, dir: str) -> bool:
+        """Returns True if the specific torque driver is present and not permanently failed.
+
+        Unlike TORQUE_DRIVERS_AVAILABLE, this ignores temp_disabled so intentional
+        hardware-disables (e.g. during VF_TUMBLING) are not mistaken for actuator failures.
+
+        :param dir: The direction key (e.g., 'XP', 'XM', etc.)
+        :return: bool
+        """
+        return (
+            self.key_in_device_list("TORQUE_" + dir)
+            and self.__device_list["TORQUE_" + dir].device is not None
+            and not self.__device_list["TORQUE_" + dir].dead
+        )
+
     def TORQUE_DRIVERS_CURRENT(self, dir: str) -> float:
         """Returns the coil current for the specific magnetorquer if available and returns -1 otherwise
 

--- a/emulator/emulator.py
+++ b/emulator/emulator.py
@@ -126,6 +126,21 @@ class EmulatedSatellite(CubeSat):
     def set_fsw_state(self, state):
         self.__simulated_spacecraft.set_fsw_state(state)
 
+    def turn_off_device(self, device_name: str) -> None:
+        if device_name.startswith("TORQUE"):
+            for name, dev in self.DEVICE_LIST.items():
+                if name.startswith("TORQUE"):
+                    dev.temp_disabled = True
+            if self.__simulated_spacecraft is not None:
+                for dir in ("XP", "XM", "YP", "YM", "ZP", "ZM"):
+                    self.__simulated_spacecraft.set_control_input(dir, 0)
+
+    def turn_on_device(self, device_name: str) -> None:
+        if device_name.startswith("TORQUE"):
+            for name, dev in self.DEVICE_LIST.items():
+                if name.startswith("TORQUE"):
+                    dev.temp_disabled = False
+
     ######################## ERROR HANDLING ########################
 
     def handle_error(self, _: str) -> int:

--- a/flight/apps/adcs/acs.py
+++ b/flight/apps/adcs/acs.py
@@ -164,10 +164,20 @@ def mcm_coil_allocator(u: np.ndarray, b: np.ndarray) -> list:
     return _COIL_STATUS
 
 
-def zero_all_coils():
+def zero_all_coils(hw_disable=False):
     """
     Sets all magnetorquer coil throttles to zero.
+    If hw_disable is True, also cuts power to the coil driver ICs via COIL_EN.
     """
     for face in _MCM_FACES:
         if SATELLITE.TORQUE_DRIVERS_AVAILABLE(face):
             SATELLITE.APPLY_MAGNETIC_CONTROL(face, 0)
+    if hw_disable:
+        SATELLITE.turn_off_device("TORQUE_XP")
+
+
+def enable_coils():
+    """
+    Re-enables coil driver ICs via COIL_EN and reinitialises I2C devices.
+    """
+    SATELLITE.turn_on_device("TORQUE_XP")

--- a/flight/hal/argus_v4.py
+++ b/flight/hal/argus_v4.py
@@ -812,6 +812,12 @@ class ArgusV4(CubeSat):
             return Errors.INVALID_DEVICE_NAME
         self.__turn_on_device(device_name)
 
+    def turn_off_device(self, device_name: str):
+        """turn_off_device: Turn off the device."""
+        if device_name not in self.__device_list:
+            return Errors.INVALID_DEVICE_NAME
+        self.__turn_off_device(device_name)
+
     def reboot(self):
         """Reboot the satellite by resetting the main power."""
         ArgusV4Power.MAIN_PWR_RESET.value = True

--- a/flight/hal/cubesat.py
+++ b/flight/hal/cubesat.py
@@ -313,6 +313,21 @@ class CubeSat:
             and not self.__device_list["TORQUE_" + dir].temp_disabled
         )
 
+    def TORQUE_DRIVERS_NOT_DEAD(self, dir: str) -> bool:
+        """Returns True if the specific torque driver is present and not permanently failed.
+
+        Unlike TORQUE_DRIVERS_AVAILABLE, this ignores temp_disabled so intentional
+        hardware-disables (e.g. during VF_TUMBLING) are not mistaken for actuator failures.
+
+        :param dir: The direction key (e.g., 'XP', 'XM', etc.)
+        :return: bool
+        """
+        return (
+            self.key_in_device_list("TORQUE_" + dir)
+            and self.__device_list["TORQUE_" + dir].device is not None
+            and not self.__device_list["TORQUE_" + dir].dead
+        )
+
     def TORQUE_DRIVERS_CURRENT(self, dir: str) -> float:
         """Returns the coil current for the specific magnetorquer if available and returns -1 otherwise
 

--- a/flight/tasks/adcs.py
+++ b/flight/tasks/adcs.py
@@ -4,6 +4,7 @@ import apps.adcs.sensors as sensors
 from apps.adcs.acs import (
     bcross_controller,
     bdot_controller,
+    enable_coils,
     mcm_coil_allocator,
     spin_stabilizing_controller,
     sun_pointing_controller,
@@ -77,6 +78,7 @@ class Task(TemplateTask):
     sun_lux = np.zeros((9,))
 
     coils_off = True
+    coil_hw_disabled = False
 
     _MAG_SAMPLE_DT = 0.08
     _MAG_N_SAMPLES = 6
@@ -110,7 +112,7 @@ class Task(TemplateTask):
 
             if SM.current_state == STATES.LOW_POWER or SM.current_state == STATES.EXPERIMENT:
                 # In low power or experiment mode, we want to conserve power by turning off the coils and not running the control cycle
-                self.ensure_coils_off()
+                self.ensure_coils_off(hw_disable=True)
             else:
                 if SM.current_state == STATES.DETUMBLING:
                     # Set bmx160 to max scale of 2000 deg/s
@@ -131,8 +133,11 @@ class Task(TemplateTask):
     # --- Attitude Control ---
     def _apply_control(self):
         if self.MODE == Modes.ACS_OFF:
-            self.ensure_coils_off()
+            self.ensure_coils_off(hw_disable=True)
             return
+        if self.coil_hw_disabled:
+            enable_coils()
+            self.coil_hw_disabled = False
         mtq_throttle = ControllerConst.FALLBACK_CONTROL
         if self.CONTROLLER_MODE == ControllerModes.BCROSS:
             if not (self.gyro_status != StatusConst.OK or self.mag_status != StatusConst.OK):
@@ -157,8 +162,11 @@ class Task(TemplateTask):
         Total duration: 5 x 0.08 + 0.5 = 0.9 s.
         """
         if self.MODE == Modes.ACS_OFF:
-            self.ensure_coils_off()
+            self.ensure_coils_off(hw_disable=True)
             return
+        if self.coil_hw_disabled:
+            enable_coils()
+            self.coil_hw_disabled = False
         self._mag_buffer = []
         for k in range(self._MAG_N_SAMPLES):
             status, reading = sensors.read_magnetometer()
@@ -210,13 +218,19 @@ class Task(TemplateTask):
 
         self.ensure_coils_off()
 
-    def ensure_coils_off(self):
+    def ensure_coils_off(self, hw_disable=False):
         """
         If the coils are not off, turn them off.
+        If hw_disable is True, also cuts COIL_EN to eliminate driver quiescent draw.
         """
         if not self.coils_off:
-            zero_all_coils()
+            zero_all_coils(hw_disable)
             self.coils_off = True
+        elif hw_disable and not self.coil_hw_disabled:
+            # Coils already zeroed; route through zero_all_coils just to cut COIL_EN
+            zero_all_coils(hw_disable=True)
+        if hw_disable:
+            self.coil_hw_disabled = True
 
     # --- Logging ---
     def log(self):

--- a/flight/tasks/command.py
+++ b/flight/tasks/command.py
@@ -363,15 +363,7 @@ class Task(TemplateTask):
                 self.log_data[CDH_IDX.DETUMBLING_ERROR_FLAG] = 1
 
             # Detumbling impossible due to magnetorquer failure
-            working_coils = [
-                SATELLITE.TORQUE_DRIVERS_AVAILABLE("XP"),
-                SATELLITE.TORQUE_DRIVERS_AVAILABLE("XM"),
-                SATELLITE.TORQUE_DRIVERS_AVAILABLE("YP"),
-                SATELLITE.TORQUE_DRIVERS_AVAILABLE("YM"),
-                SATELLITE.TORQUE_DRIVERS_AVAILABLE("ZP"),
-                SATELLITE.TORQUE_DRIVERS_AVAILABLE("ZM"),
-            ]
-            if not any(working_coils):
+            if not any(SATELLITE.TORQUE_DRIVERS_NOT_DEAD(d) for d in ("XP", "XM", "YP", "YM", "ZP", "ZM")):
                 self.log_info("DETUMBLING actuator failure - Setting Detumbling Error Flag.")
                 # Set the detumbling error flag in the NVM
                 self.log_data[CDH_IDX.DETUMBLING_ERROR_FLAG] = 1


### PR DESCRIPTION
Magnetorquer coils consume ~0.1 W at rest. Disabling them lowers power consumption in low power mode by 15%. 

This PR has them disabled when in low power mode, or when adcs mode is acs_off, which is met when the sc has successfully detumbled or sun pointed, depending on the controller being used. The coils will still be kept enabled during the on/off cycling of the ADCS task to alternate between magnetometer measurement and magnetorquer actuation.