### PR TITLE
Digipeater fix

### DIFF
--- a/flight/apps/digipeater/__init__.py
+++ b/flight/apps/digipeater/__init__.py
@@ -19,7 +19,7 @@ class DigipeaterState:
 
         cls.active = True
 
-        # Valid packets received while the digipeater is disabled 
+        # Valid packets received while the digipeater is disabled
         # will be inserted into the queue, and transmitted once its
         # activated. This will clear the packets on init
         DigipeaterRxQueue.clear()

--- a/flight/apps/digipeater/__init__.py
+++ b/flight/apps/digipeater/__init__.py
@@ -19,6 +19,11 @@ class DigipeaterState:
 
         cls.active = True
 
+        # Valid packets received while the digipeater is disabled 
+        # will be inserted into the queue, and transmitted once its
+        # activated. This will clear the packets on init
+        DigipeaterRxQueue.clear()
+
         task = SM.scheduled_tasks.get(TASK.DIGIPEATER)
         if task is None:
             return ["digipeater_task_not_scheduled"]

--- a/flight/apps/digipeater/aprs.py
+++ b/flight/apps/digipeater/aprs.py
@@ -18,29 +18,16 @@ def is_valid_lora_aprs_packet(data, re_obj):
     """Return True if data is a structurally valid LoRa APRS packet."""
 
     # check if there are enough bytes
-    if len(data) < _HEADER_LEN + 20:  # header + minimum APRS string length
+    if len(data) < _HEADER_LEN + 9:  # header + minimum APRS string length
         return 1
 
     # try an decode using ascii
     try:
         aprs_str = data[_HEADER_LEN:].decode("ascii")
     except (UnicodeDecodeError, ValueError):
-        return 3
+        return 2
 
-    # use re_obj to check if the satellite callsing is in the string
-    result = re_obj.search(aprs_str)
-    if result is None:
-        return 4
-
-    # ind max size: 10 (because of ssid)
-    # dst max size: 6
-    # extra chars: header + > = 4
-    # the maximum distance from the beggining of the string should be 20
-    # check if the callsign is in the first 20 characters of the string
-    if result.start() > 20:
-        return 5
-
-    return 6
+    return 4 if re_obj.match(aprs_str) else 3
 
 
 def add_asterisk_packet(data, re_obj):

--- a/flight/apps/digipeater/aprs.py
+++ b/flight/apps/digipeater/aprs.py
@@ -30,8 +30,9 @@ def is_valid_lora_aprs_packet(data, re_obj):
     return 4 if re_obj.match(aprs_str) else 3
 
 
-def add_asterisk_packet(data, re_obj):
+def add_asterisk_packet(data, re_obj, callsign):
     """
     Will simply add an asterisk to the end of callsign in the path to indicate that the packed has been repeated
     """
-    return re_obj.sub(r"\g<0>*", data)
+    replacement = "\\1\\2\\3\\5\\6" + callsign + "*" + "\\8\\10"
+    return re_obj.sub(replacement, data)

--- a/flight/tasks/digipeater.py
+++ b/flight/tasks/digipeater.py
@@ -40,7 +40,13 @@ class Task(TemplateTask):
         self.max_rx_queue = int(getattr(CONFIG, "RX_QUEUE_MAX", 20))
 
         # create the RE to find satellite CS in the path
-        self._satellite_cs_re = re.compile(f"{SATELLITE_RADIO.SC_CALLSIGN}")
+        self._satellite_cs_re = re.compile(
+            r"^[a-zA-Z0-9]{6}"                 # Standard raw string
+            r"(?:-(?:[1-9]|1[0-5]))?>"
+            r"(?:[a-zA-Z0-9]{1,6},)?"
+            f"{SATELLITE_RADIO.SC_CALLSIGN}"
+            r"(?:(?:,[^:]*)?:|:)"              # Standard raw string
+        )
 
         DigipeaterRxQueue.configure(self.max_rx_queue)
 
@@ -58,8 +64,8 @@ class Task(TemplateTask):
 
             # Validate LoRa APRS packet header and structure
             result = is_valid_lora_aprs_packet(raw_packet, self._satellite_cs_re)
-            if not result == 6:
-                self.log_warning(f"  Invalid packet format, dropping {result}")
+            if not result == 4:
+                self.log_warning(f"Invalid packet format, dropping {result}")
                 continue
 
             # Add asterik to callsign to indicate digipeating

--- a/flight/tasks/digipeater.py
+++ b/flight/tasks/digipeater.py
@@ -39,14 +39,31 @@ class Task(TemplateTask):
 
         self.max_rx_queue = int(getattr(CONFIG, "RX_QUEUE_MAX", 20))
 
-        # create the RE to find satellite CS in the path
-        self._satellite_cs_re = re.compile(
-            r"^[a-zA-Z0-9]{6}"                 # Standard raw string
-            r"(?:-(?:[1-9]|1[0-5]))?>"
-            r"(?:[a-zA-Z0-9]{1,6},)?"
-            f"{SATELLITE_RADIO.SC_CALLSIGN}"
-            r"(?:(?:,[^:]*)?:|:)"              # Standard raw string
-        )
+        # Prefix (Bytes)
+        prefix = "^(.*?)" 
+        # SRC (6 chars) - Wrapped in () so it becomes Group 2
+        src = "([A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9])"
+        # Suffix - Groups 3 & 4
+        suffix = "(-(1[0-5]|[1-9]))?"
+        # Separator - Group 5
+        sep = "(>)"
+        # DST - Group 6
+        dst = "([A-Za-z0-9]+,)?"
+        # Code - Group 7
+        callsign = "(" + SATELLITE_RADIO.SC_CALLSIGN + ")"
+        # Tail - Groups 8 & 9
+        tail = "((,[^:]*)?:)"
+        # Rest - Group 10
+        rest = "(.*)"
+
+        pattern = "^" + src + suffix + sep + \
+            dst + callsign + tail
+
+        pattern_with_rest = prefix + src + suffix + sep + \
+            dst + callsign + tail + rest
+
+        self._satellite_message_re = re.compile(pattern)
+        self._satellite_replace_re = re.compile(pattern_with_rest)
 
         DigipeaterRxQueue.configure(self.max_rx_queue)
 
@@ -63,13 +80,14 @@ class Task(TemplateTask):
             self.log_info(f"Looking at packet: {raw_packet[:20]}")
 
             # Validate LoRa APRS packet header and structure
-            result = is_valid_lora_aprs_packet(raw_packet, self._satellite_cs_re)
+            result = is_valid_lora_aprs_packet(raw_packet, self._satellite_message_re)
             if not result == 4:
                 self.log_warning(f"Invalid packet format, dropping {result}")
                 continue
 
             # Add asterik to callsign to indicate digipeating
-            final_packet = add_asterisk_packet(raw_packet, self._satellite_cs_re)
+            final_packet = add_asterisk_packet(raw_packet, self._satellite_replace_re,
+                                               SATELLITE_RADIO.SC_CALLSIGN)
 
             # Transmit using special transmit digi packet function
             if not SATELLITE_RADIO.transmit_digi_packet(final_packet):

--- a/flight/tasks/digipeater.py
+++ b/flight/tasks/digipeater.py
@@ -40,7 +40,7 @@ class Task(TemplateTask):
         self.max_rx_queue = int(getattr(CONFIG, "RX_QUEUE_MAX", 20))
 
         # Prefix (Bytes)
-        prefix = "^(.*?)" 
+        prefix = "^(.*?)"
         # SRC (6 chars) - Wrapped in () so it becomes Group 2
         src = "([A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9])"
         # Suffix - Groups 3 & 4


### PR DESCRIPTION
This PR changes how the digipeater looks for valid packets and how it creates the packets to digipeat.
As is, the code allows for a large variety of packets with invalid formats. With the implemented regex rules, the verification is stricter (although not perfect).

During testing, we saw no increase in RAM usage.