### PR TITLE
Fix Radio Rebooting Error

### DIFF
--- a/flight/hal/argus_v4.py
+++ b/flight/hal/argus_v4.py
@@ -691,6 +691,7 @@ class ArgusV4(CubeSat):
 
         if device_name == "RADIO":
             device_cls.temp_disabled = True
+            self.__device_list["RADIO_PWR"].temp_disabled = True
             if device_cls.device is not None:
                 device_cls.device.deinit()
             self.__turn_off_power_line(ArgusV4Power.RADIO_EN)
@@ -721,8 +722,15 @@ class ArgusV4(CubeSat):
 
         if device_name == "RADIO":
             self.__turn_on_power_line(ArgusV4Power.RADIO_EN)
+            # time.sleep(0.1)
             self.__boot_device(device_name, device_cls)
             device_cls.temp_disabled = False
+            if device_cls.device is not None:
+                device_cls.device.startReceive(0xFFFFFF)
+            radio_power_monitor = self.__device_list["RADIO_PWR"]
+            if not radio_power_monitor.dead:
+                self.__boot_device("RADIO_PWR", radio_power_monitor)
+                radio_power_monitor.temp_disabled = False
 
         elif device_name == "GPS":
             self.__turn_on_power_line(ArgusV4Power.GPS_EN)
@@ -756,7 +764,9 @@ class ArgusV4(CubeSat):
         device_cls = self.__device_list[device_name]
 
         device_cls.error_count += 1
-        if self.check_device_dead(device_cls.error_count):
+        if device_name == "RADIO":
+            device_cls.error_count = min(device_cls.error_count, ArgusV4Error.MAX_DEVICE_ERROR)
+        elif self.check_device_dead(device_cls.error_count):
             device_cls.dead = True
             device_cls.device = None
             return Errors.DEVICE_DEAD

--- a/flight/hal/argus_v4.py
+++ b/flight/hal/argus_v4.py
@@ -691,7 +691,6 @@ class ArgusV4(CubeSat):
 
         if device_name == "RADIO":
             device_cls.temp_disabled = True
-            self.__device_list["RADIO_PWR"].temp_disabled = True
             if device_cls.device is not None:
                 device_cls.device.deinit()
             self.__turn_off_power_line(ArgusV4Power.RADIO_EN)
@@ -722,15 +721,8 @@ class ArgusV4(CubeSat):
 
         if device_name == "RADIO":
             self.__turn_on_power_line(ArgusV4Power.RADIO_EN)
-            # time.sleep(0.1)
             self.__boot_device(device_name, device_cls)
             device_cls.temp_disabled = False
-            if device_cls.device is not None:
-                device_cls.device.startReceive(0xFFFFFF)
-            radio_power_monitor = self.__device_list["RADIO_PWR"]
-            if not radio_power_monitor.dead:
-                self.__boot_device("RADIO_PWR", radio_power_monitor)
-                radio_power_monitor.temp_disabled = False
 
         elif device_name == "GPS":
             self.__turn_on_power_line(ArgusV4Power.GPS_EN)

--- a/flight/tasks/hal_monitor.py
+++ b/flight/tasks/hal_monitor.py
@@ -150,10 +150,11 @@ class Task(TemplateTask):
                             else:
                                 key_name = self.idx_to_hal_name(idx)
                                 if "_ERROR_COUNT" in key_name:
-                                    SATELLITE.update_device_error_count(key_name.replace("_ERROR_COUNT", ""), value)
+                                    device_name = key_name.replace("_ERROR_COUNT", "")
+                                    SATELLITE.update_device_error_count(device_name, value)
                                     self.log_debug(f"Restored {key_name} to {value}")
-                                    if SATELLITE.check_device_dead(value):
-                                        SATELLITE.update_device_dead(key_name.replace("_ERROR_COUNT", ""), True)
+                                    if device_name != "RADIO" and SATELLITE.check_device_dead(value):
+                                        SATELLITE.update_device_dead(device_name, True)
                                         self.log_error(f"Restored {key_name} to dead")
                                 elif "_ERROR" in key_name:
                                     pass
@@ -176,7 +177,7 @@ class Task(TemplateTask):
         # restart devices that are turned off(individual power switches)
         if (TPM.monotonic() - self.individual_reboot_counter) >= _INDIVIDUAL_REBOOT_INTERVAL:
             if self.turn_on_device != {}:
-                for device_name, time in self.turn_on_device.items():
+                for device_name, time in list(self.turn_on_device.items()):  # this needs to be a list if the dict updates during iteration, you can't read it directly
                     if self.log_data[HAL_IDX.TIME_HAL] != time:
                         SATELLITE.turn_on_device(device_name)
                         self.log_warning(f"Turned on {device_name} and devices on the same power line.")


### PR DESCRIPTION
Fixes the Radio Reboot behavior. Now restarts into Rx
Radio does not enter a dead state
Current sensor does not get read as dead when Radio is turned off
