### PR TITLE
Storage tm fix

### DIFF
--- a/flight/apps/telemetry/middleware.py
+++ b/flight/apps/telemetry/middleware.py
@@ -107,7 +107,7 @@ class Frame:
             "adcs",
             "comms",
             "gps",
-            "payload",
+            "payload_tm",
             "cmd_logs",
             "hal",
             "eps_warning"

--- a/flight/tasks/gps.py
+++ b/flight/tasks/gps.py
@@ -69,6 +69,9 @@ class Task(TemplateTask):
 
                     # data limit is around 100minutes. No need to make it smaller for downlink
                     DH.register_data_process("gps", data_format, True, data_limit=25000, write_interval=4)
+                    # Force writing once to make sure it creates the file in case we never get gps update
+                    # this will avoid an error when requesting tm_storage
+                    DH.log_data("gps", self.log_data)
 
                 # Check if the module sent a valid nav data message
                 if SATELLITE.GPS.update():


### PR DESCRIPTION
Payload tm in storage data was wrong and we were getting no data from it


data handler process does not create the file until the first data is written and the gps would only write data when it had updates. If the gps never had updates, request tm storage would always give an error when trying to get the data from the sd data process. So forced a write when the data process is created to avoid that error

HAD TO UPDATE SPLAT
and since i was already updating splat, also removed a print in the transaction that was missed
